### PR TITLE
fix: add additional params to deploy()

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -181,7 +181,7 @@ class Juju:
         if app is not None:
             args.append(app)
 
-        if attach_storage is not None:
+        if attach_storage:
             if isinstance(attach_storage, str):
                 args.extend(['--attach-storage', attach_storage])
             else:
@@ -208,7 +208,7 @@ class Juju:
         if storage is not None:
             for k, v in storage.items():
                 args.extend(['--storage' f'{k}={v}'])
-        if to is not None:
+        if to:
             if isinstance(to, str):
                 args.extend(['--to', to])
             else:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -207,7 +207,7 @@ class Juju:
             args.extend(['--revision', str(revision)])
         if storage is not None:
             for k, v in storage.items():
-                args.extend(['--storage' f'{k}={v}'])
+                args.extend(['--storage', f'{k}={v}'])
         if to:
             if isinstance(to, str):
                 args.extend(['--to', to])

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -3,7 +3,7 @@ import logging
 import os
 import subprocess
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 from ._errors import CLIError, WaitError
 from ._types import Status
@@ -104,7 +104,7 @@ class Juju:
         charm: str | os.PathLike,
         app: str | None = None,
         *,
-        attach_storage: str | list[str] | None = None,
+        attach_storage: str | Iterable[str] | None = None,
         base: str | None = None,
         channel: str | None = None,
         config: dict[str, bool | int | float | str] | None = None,
@@ -114,10 +114,32 @@ class Juju:
         resource: dict[str, str] | None = None,
         revision: int | None = None,
         storage: dict[str, str] | None = None,
-        to: str | list[str] | None = None,
+        to: str | Iterable[str] | None = None,
         trust: bool = False,
     ) -> None:
-        """Deploy an application or bundle."""
+        """Deploy an application or bundle.
+
+        Args:
+            charm: Name of charm or bundle to deploy, or path to a local file (must start with
+                ``/`` or ``.``).
+            app: Optional application name within the model; defaults to the charm name.
+            attach_storage: Existing storage(s) to attach to the deployed unit, for example,
+                ``foo/0`` or ``mydisk/1``. Not available for Kubernetes models.
+            base: The base on which to deploy, for example, ``ubuntu@22.04``.
+            channel: Channel to use when deploying from Charmhub, for example, ``latest/edge``.
+            config: Application configuration as key-value pairs, for example,
+                ``{'name': 'My Wiki'}``.
+            constraints: Hardware constraints for new machines, for example, ``{'mem': '8G'}``.
+            force: If true, bypass checks such as supported bases.
+            num_units: Number of units to deploy for principal charms.
+            resource: Specify named resources to use for deployment, for example:
+                ``{'bin': '/path/to/some/binary'}``.
+            revision: Charmhub revision number to deploy.
+            storage: Constraints for named storage(s), for example, ``{'data': 'tmpfs,1G'}``.
+            to: Machine or container to deploy the unit in (bypasses constraints). For example,
+                to deploy to a new LXD container on machine 25, use ``lxd:25``.
+            trust: If true, allows charm to run hooks that require access to cloud credentials.
+        """
         args = ['deploy', charm]
         if app is not None:
             args.append(app)

--- a/test/unit/test_basic.py
+++ b/test/unit/test_basic.py
@@ -3,4 +3,4 @@ import jubilant
 
 def test_repr():
     juju = jubilant.Juju()
-    assert repr(juju) == 'Juju()'
+    assert repr(juju) == "Juju(model=None, wait_timeout=180.0, cli_binary='juju')"


### PR DESCRIPTION
This PR adds additional arguments for the `deploy` method -- all I think people will use (and possibly more). Design decisions:

- Make the parameter names match the CLI argument names 1:1, even when a plural might make more sense.
- In cases where a str is likely or natural, but a list can also be provided, allow `str | Iterable[str]`.

Also:

- Fix config values when the type is `bool` (should be Go-style lowercase "true" and "false").
- Add docstring "Args:" sections to most methods.
- Simplify `__repr__`.