### PR TITLE
feat: add generated status dataclasses

### DIFF
--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -1,5 +1,6 @@
 """Jubilant is a Pythonic wrapper around the Juju CLI for integration testing."""
 
+from . import types
 from ._errors import CLIError, WaitError
 from ._helpers import (
     all_active,
@@ -31,6 +32,7 @@ __all__ = [
     'any_error',
     'any_maintenance',
     'any_waiting',
+    'types',
 ]
 
 __version__ = '0.0.0a1'

--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -14,7 +14,7 @@ from ._helpers import (
     any_waiting,
 )
 from ._juju import Juju
-from ._types import Status
+from .types import Status
 
 __all__ = [
     'CLIError',

--- a/jubilant/_helpers.py
+++ b/jubilant/_helpers.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 
-from ._types import Status
+from .types import Status
 
 
 def all_active(status: Status, apps: Iterable[str] | None = None) -> bool:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Callable, Iterable
 
 from ._errors import CLIError, WaitError
-from ._types import Status
+from .types import Status
 
 logger = logging.getLogger('jubilant')
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -223,7 +223,7 @@ class Juju:
         args = ['status', '--format', 'json']
         stdout = self.cli(*args)
         result = json.loads(stdout)
-        return Status.from_dict(result)
+        return Status._from_dict(result)
 
     def wait(
         self,

--- a/jubilant/_types.py
+++ b/jubilant/_types.py
@@ -159,10 +159,11 @@ class AppStatus:
             raise StatusError(d['status-error'])
         return cls(
             charm=d['charm'],
-            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
             charm_origin=d['charm-origin'],
             charm_name=d['charm-name'],
             charm_rev=d['charm-rev'],
+            exposed=d['exposed'],
+            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
             charm_channel=d.get('charm-channel') or '',
             charm_version=d.get('charm-version') or '',
             charm_profile=d.get('charm-profile') or '',
@@ -170,7 +171,6 @@ class AppStatus:
             scale=d.get('scale') or 0,
             provider_id=d.get('provider-id') or '',
             address=d.get('address') or '',
-            exposed=d['exposed'],
             life=d.get('life') or '',
             app_status=(
                 StatusInfoContents.from_dict(d['application-status'])
@@ -270,9 +270,9 @@ class StorageInfo:
     def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
         return cls(
             kind=d['kind'],
-            life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']),
             persistent=d['persistent'],
+            life=d.get('life') or '',
             attachments=(
                 StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None
             ),
@@ -324,7 +324,7 @@ class FilesystemAttachments:
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FilesystemInfo:
-    Attachments: FilesystemAttachments
+    attachments: FilesystemAttachments
     size: int
 
     provider_id: str = ''
@@ -337,12 +337,12 @@ class FilesystemInfo:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
         return cls(
+            attachments=FilesystemAttachments.from_dict(d['Attachments']),
+            size=d['size'],
             provider_id=d.get('provider-id') or '',
             volume=d.get('volume') or '',
             storage=d.get('storage') or '',
-            Attachments=FilesystemAttachments.from_dict(d['Attachments']),
             pool=d.get('pool') or '',
-            size=d['size'],
             life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
@@ -360,10 +360,10 @@ class VolumeAttachment:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
         return cls(
+            read_only=d['read-only'],
             device=d.get('device') or '',
             device_link=d.get('device-link') or '',
             bus_address=d.get('bus-address') or '',
-            read_only=d['read-only'],
             life=d.get('life') or '',
         )
 
@@ -412,6 +412,8 @@ class VolumeInfo:
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
         return cls(
+            size=d['size'],
+            persistent=d['persistent'],
             provider_id=d.get('provider-id') or '',
             storage=d.get('storage') or '',
             attachments=(
@@ -422,8 +424,6 @@ class VolumeInfo:
             pool=d.get('pool') or '',
             hardware_id=d.get('hardware-id') or '',
             wwn=d.get('wwn') or '',
-            size=d['size'],
-            persistent=d['persistent'],
             life=d.get('life') or '',
             status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
@@ -497,10 +497,10 @@ class NetworkInterface:
         return cls(
             ip_addresses=d['ip-addresses'],
             mac_address=d['mac-address'],
+            is_up=d['is-up'],
             gateway=d.get('gateway') or '',
             dns_nameservers=d.get('dns-nameservers') or [],
             space=d.get('space') or '',
-            is_up=d['is-up'],
         )
 
 
@@ -590,8 +590,8 @@ class ModelStatus:
             type=d['type'],
             controller=d['controller'],
             cloud=d['cloud'],
-            region=d.get('region') or '',
             version=d['version'],
+            region=d.get('region') or '',
             upgrade_available=d.get('upgrade-available') or '',
             model_status=(
                 StatusInfoContents.from_dict(d['model-status'])
@@ -629,10 +629,10 @@ class OfferStatus:
             raise StatusError(d['status-error'])
         return cls(
             app=d['application'],
+            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
             charm=d.get('charm') or '',
             total_connected_count=d.get('total-connected-count') or 0,
             active_connected_count=d.get('active-connected-count') or 0,
-            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
         )
 
 

--- a/jubilant/_types.py
+++ b/jubilant/_types.py
@@ -16,7 +16,7 @@ class FormattedBase:
     channel: str
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FormattedBase:
+    def _from_dict(cls, d: dict[str, Any]) -> FormattedBase:
         return cls(
             name=d['name'],
             channel=d['channel'],
@@ -33,7 +33,7 @@ class StatusInfoContents:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
+    def _from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
@@ -53,7 +53,7 @@ class AppStatusRelation:
     scope: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
+    def _from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
         return cls(
             related_app=d.get('related-application') or '',
             interface=d.get('interface') or '',
@@ -75,17 +75,17 @@ class UnitStatus:
     subordinates: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> UnitStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             workload_status=(
-                StatusInfoContents.from_dict(d['workload-status'])
+                StatusInfoContents._from_dict(d['workload-status'])
                 if 'workload-status' in d
                 else StatusInfoContents()
             ),
             juju_status=(
-                StatusInfoContents.from_dict(d['juju-status'])
+                StatusInfoContents._from_dict(d['juju-status'])
                 if 'juju-status' in d
                 else StatusInfoContents()
             ),
@@ -97,7 +97,7 @@ class UnitStatus:
             address=d.get('address') or '',
             provider_id=d.get('provider-id') or '',
             subordinates=(
-                {k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()}
+                {k: UnitStatus._from_dict(v) for k, v in d['subordinates'].items()}
                 if 'subordinates' in d
                 else {}
             ),
@@ -154,7 +154,7 @@ class AppStatus:
     endpoint_bindings: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> AppStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> AppStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
@@ -163,7 +163,7 @@ class AppStatus:
             charm_name=d['charm-name'],
             charm_rev=d['charm-rev'],
             exposed=d['exposed'],
-            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            base=FormattedBase._from_dict(d['base']) if 'base' in d else None,
             charm_channel=d.get('charm-channel') or '',
             charm_version=d.get('charm-version') or '',
             charm_profile=d.get('charm-profile') or '',
@@ -173,18 +173,23 @@ class AppStatus:
             address=d.get('address') or '',
             life=d.get('life') or '',
             app_status=(
-                StatusInfoContents.from_dict(d['application-status'])
+                StatusInfoContents._from_dict(d['application-status'])
                 if 'application-status' in d
                 else StatusInfoContents()
             ),
             relations=(
-                {k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()}
+                {
+                    k: [AppStatusRelation._from_dict(x) for x in v]
+                    for k, v in d['relations'].items()
+                }
                 if 'relations' in d
                 else {}
             ),
             subordinate_to=d.get('subordinate-to') or [],
             units=(
-                {k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {}
+                {k: UnitStatus._from_dict(v) for k, v in d['units'].items()}
+                if 'units' in d
+                else {}
             ),
             version=d.get('version') or '',
             endpoint_bindings=d.get('endpoint-bindings') or {},
@@ -223,7 +228,7 @@ class EntityStatus:
     since: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> EntityStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> EntityStatus:
         return cls(
             current=d.get('current') or '',
             message=d.get('message') or '',
@@ -238,7 +243,7 @@ class UnitStorageAttachment:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
+    def _from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
         return cls(
             machine=d.get('machine') or '',
             location=d.get('location') or '',
@@ -251,9 +256,9 @@ class StorageAttachments:
     units: dict[str, UnitStorageAttachment]
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> StorageAttachments:
+    def _from_dict(cls, d: dict[str, Any]) -> StorageAttachments:
         return cls(
-            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()},
+            units={k: UnitStorageAttachment._from_dict(v) for k, v in d['units'].items()},
         )
 
 
@@ -267,14 +272,14 @@ class StorageInfo:
     attachments: StorageAttachments | None = None
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
+    def _from_dict(cls, d: dict[str, Any]) -> StorageInfo:
         return cls(
             kind=d['kind'],
-            status=EntityStatus.from_dict(d['status']),
+            status=EntityStatus._from_dict(d['status']),
             persistent=d['persistent'],
             life=d.get('life') or '',
             attachments=(
-                StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None
+                StorageAttachments._from_dict(d['attachments']) if 'attachments' in d else None
             ),
         )
 
@@ -287,7 +292,7 @@ class FilesystemAttachment:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
+    def _from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
         return cls(
             mount_point=d['mount-point'],
             read_only=d['read-only'],
@@ -302,20 +307,20 @@ class FilesystemAttachments:
     units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
+    def _from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
         return cls(
             machines=(
-                {k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()}
+                {k: FilesystemAttachment._from_dict(v) for k, v in d['machines'].items()}
                 if 'machines' in d
                 else {}
             ),
             containers=(
-                {k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()}
+                {k: FilesystemAttachment._from_dict(v) for k, v in d['containers'].items()}
                 if 'containers' in d
                 else {}
             ),
             units=(
-                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                {k: UnitStorageAttachment._from_dict(v) for k, v in d['units'].items()}
                 if 'units' in d
                 else {}
             ),
@@ -324,27 +329,31 @@ class FilesystemAttachments:
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class FilesystemInfo:
-    attachments: FilesystemAttachments
     size: int
 
     provider_id: str = ''
     volume: str = ''
     storage: str = ''
+    attachments: FilesystemAttachments = dataclasses.field(default_factory=FilesystemAttachments)
     pool: str = ''
     life: str = ''
     status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
+    def _from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
         return cls(
-            attachments=FilesystemAttachments.from_dict(d['Attachments']),
             size=d['size'],
             provider_id=d.get('provider-id') or '',
             volume=d.get('volume') or '',
             storage=d.get('storage') or '',
+            attachments=(
+                FilesystemAttachments._from_dict(d['attachments'])
+                if 'attachments' in d
+                else FilesystemAttachments()
+            ),
             pool=d.get('pool') or '',
             life=d.get('life') or '',
-            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
+            status=EntityStatus._from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
 
 
@@ -358,7 +367,7 @@ class VolumeAttachment:
     life: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
+    def _from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
         return cls(
             read_only=d['read-only'],
             device=d.get('device') or '',
@@ -375,20 +384,20 @@ class VolumeAttachments:
     units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
+    def _from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
         return cls(
             machines=(
-                {k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()}
+                {k: VolumeAttachment._from_dict(v) for k, v in d['machines'].items()}
                 if 'machines' in d
                 else {}
             ),
             containers=(
-                {k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()}
+                {k: VolumeAttachment._from_dict(v) for k, v in d['containers'].items()}
                 if 'containers' in d
                 else {}
             ),
             units=(
-                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                {k: UnitStorageAttachment._from_dict(v) for k, v in d['units'].items()}
                 if 'units' in d
                 else {}
             ),
@@ -410,14 +419,14 @@ class VolumeInfo:
     status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
+    def _from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
         return cls(
             size=d['size'],
             persistent=d['persistent'],
             provider_id=d.get('provider-id') or '',
             storage=d.get('storage') or '',
             attachments=(
-                VolumeAttachments.from_dict(d['attachments'])
+                VolumeAttachments._from_dict(d['attachments'])
                 if 'attachments' in d
                 else VolumeAttachments()
             ),
@@ -425,7 +434,7 @@ class VolumeInfo:
             hardware_id=d.get('hardware-id') or '',
             wwn=d.get('wwn') or '',
             life=d.get('life') or '',
-            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
+            status=EntityStatus._from_dict(d['status']) if 'status' in d else EntityStatus(),
         )
 
 
@@ -436,20 +445,20 @@ class CombinedStorage:
     volumes: dict[str, VolumeInfo] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
+    def _from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
         return cls(
             storage=(
-                {k: StorageInfo.from_dict(v) for k, v in d['storage'].items()}
+                {k: StorageInfo._from_dict(v) for k, v in d['storage'].items()}
                 if 'storage' in d
                 else {}
             ),
             filesystems=(
-                {k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()}
+                {k: FilesystemInfo._from_dict(v) for k, v in d['filesystems'].items()}
                 if 'filesystems' in d
                 else {}
             ),
             volumes=(
-                {k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()}
+                {k: VolumeInfo._from_dict(v) for k, v in d['volumes'].items()}
                 if 'volumes' in d
                 else {}
             ),
@@ -461,7 +470,7 @@ class ControllerStatus:
     timestamp: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
         return cls(
             timestamp=d.get('timestamp') or '',
         )
@@ -474,7 +483,7 @@ class LxdProfileContents:
     devices: dict[str, dict[str, str]]
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
+    def _from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
         return cls(
             config=d['config'],
             description=d['description'],
@@ -493,7 +502,7 @@ class NetworkInterface:
     space: str = ''
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
+    def _from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
         return cls(
             ip_addresses=d['ip-addresses'],
             mac_address=d['mac-address'],
@@ -524,12 +533,12 @@ class MachineStatus:
     lxd_profiles: dict[str, LxdProfileContents] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> MachineStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             juju_status=(
-                StatusInfoContents.from_dict(d['juju-status'])
+                StatusInfoContents._from_dict(d['juju-status'])
                 if 'juju-status' in d
                 else StatusInfoContents()
             ),
@@ -539,23 +548,23 @@ class MachineStatus:
             instance_id=d.get('instance-id') or '',
             display_name=d.get('display-name') or '',
             machine_status=(
-                StatusInfoContents.from_dict(d['machine-status'])
+                StatusInfoContents._from_dict(d['machine-status'])
                 if 'machine-status' in d
                 else StatusInfoContents()
             ),
             modification_status=(
-                StatusInfoContents.from_dict(d['modification-status'])
+                StatusInfoContents._from_dict(d['modification-status'])
                 if 'modification-status' in d
                 else StatusInfoContents()
             ),
-            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            base=FormattedBase._from_dict(d['base']) if 'base' in d else None,
             network_interfaces=(
-                {k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()}
+                {k: NetworkInterface._from_dict(v) for k, v in d['network-interfaces'].items()}
                 if 'network-interfaces' in d
                 else {}
             ),
             containers=(
-                {k: MachineStatus.from_dict(v) for k, v in d['containers'].items()}
+                {k: MachineStatus._from_dict(v) for k, v in d['containers'].items()}
                 if 'containers' in d
                 else {}
             ),
@@ -564,7 +573,7 @@ class MachineStatus:
             controller_member_status=d.get('controller-member-status') or '',
             ha_primary=d.get('ha-primary') or False,
             lxd_profiles=(
-                {k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()}
+                {k: LxdProfileContents._from_dict(v) for k, v in d['lxd-profiles'].items()}
                 if 'lxd-profiles' in d
                 else {}
             ),
@@ -584,7 +593,7 @@ class ModelStatus:
     model_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> ModelStatus:
         return cls(
             name=d['name'],
             type=d['type'],
@@ -594,7 +603,7 @@ class ModelStatus:
             region=d.get('region') or '',
             upgrade_available=d.get('upgrade-available') or '',
             model_status=(
-                StatusInfoContents.from_dict(d['model-status'])
+                StatusInfoContents._from_dict(d['model-status'])
                 if 'model-status' in d
                 else StatusInfoContents()
             ),
@@ -607,7 +616,7 @@ class RemoteEndpoint:
     role: str
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> RemoteEndpoint:
+    def _from_dict(cls, d: dict[str, Any]) -> RemoteEndpoint:
         return cls(
             interface=d['interface'],
             role=d['role'],
@@ -624,12 +633,12 @@ class OfferStatus:
     active_connected_count: int = 0
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> OfferStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             app=d['application'],
-            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
+            endpoints={k: RemoteEndpoint._from_dict(v) for k, v in d['endpoints'].items()},
             charm=d.get('charm') or '',
             total_connected_count=d.get('total-connected-count') or 0,
             active_connected_count=d.get('active-connected-count') or 0,
@@ -646,19 +655,19 @@ class RemoteAppStatus:
     relations: dict[str, list[str]] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
+    def _from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
         if 'status-error' in d:
             raise StatusError(d['status-error'])
         return cls(
             url=d['url'],
             endpoints=(
-                {k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()}
+                {k: RemoteEndpoint._from_dict(v) for k, v in d['endpoints'].items()}
                 if 'endpoints' in d
                 else {}
             ),
             life=d.get('life') or '',
             app_status=(
-                StatusInfoContents.from_dict(d['application-status'])
+                StatusInfoContents._from_dict(d['application-status'])
                 if 'application-status' in d
                 else StatusInfoContents()
             ),
@@ -678,26 +687,26 @@ class Status:
     controller: ControllerStatus = dataclasses.field(default_factory=ControllerStatus)
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> Status:
+    def _from_dict(cls, d: dict[str, Any]) -> Status:
         return cls(
-            model=ModelStatus.from_dict(d['model']),
-            machines={k: MachineStatus.from_dict(v) for k, v in d['machines'].items()},
-            apps={k: AppStatus.from_dict(v) for k, v in d['applications'].items()},
+            model=ModelStatus._from_dict(d['model']),
+            machines={k: MachineStatus._from_dict(v) for k, v in d['machines'].items()},
+            apps={k: AppStatus._from_dict(v) for k, v in d['applications'].items()},
             app_endpoints=(
-                {k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()}
+                {k: RemoteAppStatus._from_dict(v) for k, v in d['application-endpoints'].items()}
                 if 'application-endpoints' in d
                 else {}
             ),
             offers=(
-                {k: OfferStatus.from_dict(v) for k, v in d['offers'].items()}
+                {k: OfferStatus._from_dict(v) for k, v in d['offers'].items()}
                 if 'offers' in d
                 else {}
             ),
             storage=(
-                CombinedStorage.from_dict(d['storage']) if 'storage' in d else CombinedStorage()
+                CombinedStorage._from_dict(d['storage']) if 'storage' in d else CombinedStorage()
             ),
             controller=(
-                ControllerStatus.from_dict(d['controller'])
+                ControllerStatus._from_dict(d['controller'])
                 if 'controller' in d
                 else ControllerStatus()
             ),

--- a/jubilant/_types.py
+++ b/jubilant/_types.py
@@ -1,28 +1,107 @@
+"""Dataclasses used to hold parsed output from "juju status --format=json"."""
+
+from __future__ import annotations
+
 import dataclasses
+from typing import Any
 
 
-@dataclasses.dataclass
-class StatusInfoContents:
-    current: str | None = None
-    message: str | None = None
+class StatusError(Exception):
+    """Raised when "juju status" returns a status-error for certain types."""
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class FormattedBase:
+    name: str
+    channel: str
 
     @classmethod
-    def from_dict(cls, d):
-        self = cls()
-        self.current = d.get('current')
-        self.message = d.get('message')
-        return self
+    def from_dict(cls, d: dict[str, Any]) -> FormattedBase:
+        return cls(
+            name=d['name'],
+            channel=d['channel'],
+        )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class StatusInfoContents:
+    current: str = ''
+    message: str = ''
+    reason: str = ''
+    since: str = ''
+    version: str = ''
+    life: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> StatusInfoContents:
+        if 'status-error' in d:
+            raise StatusError(d['status-error'])
+        return cls(
+            current=d.get('current') or '',
+            message=d.get('message') or '',
+            reason=d.get('reason') or '',
+            since=d.get('since') or '',
+            version=d.get('version') or '',
+            life=d.get('life') or '',
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class AppStatusRelation:
+    related_app: str = ''
+    interface: str = ''
+    scope: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
+        return cls(
+            related_app=d.get('related-application') or '',
+            interface=d.get('interface') or '',
+            scope=d.get('scope') or '',
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class UnitStatus:
     workload_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    juju_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    leader: bool = False
+    upgrading_from: str = ''
+    machine: str = ''
+    open_ports: list[str] = dataclasses.field(default_factory=list)
+    public_address: str = ''
+    address: str = ''
+    provider_id: str = ''
+    subordinates: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d):
-        self = cls()
-        self.workload_status = StatusInfoContents.from_dict(d.get('workload-status') or {})
-        return self
+    def from_dict(cls, d: dict[str, Any]) -> UnitStatus:
+        if 'status-error' in d:
+            raise StatusError(d['status-error'])
+        return cls(
+            workload_status=(
+                StatusInfoContents.from_dict(d['workload-status'])
+                if 'workload-status' in d
+                else StatusInfoContents()
+            ),
+            juju_status=(
+                StatusInfoContents.from_dict(d['juju-status'])
+                if 'juju-status' in d
+                else StatusInfoContents()
+            ),
+            leader=d.get('leader') or False,
+            upgrading_from=d.get('upgrading-from') or '',
+            machine=d.get('machine') or '',
+            open_ports=d.get('open-ports') or [],
+            public_address=d.get('public-address') or '',
+            address=d.get('address') or '',
+            provider_id=d.get('provider-id') or '',
+            subordinates=(
+                {k: UnitStatus.from_dict(v) for k, v in d['subordinates'].items()}
+                if 'subordinates' in d
+                else {}
+            ),
+        )
 
     @property
     def is_active(self) -> bool:
@@ -50,16 +129,66 @@ class UnitStatus:
         return self.workload_status.current == 'waiting'
 
 
-@dataclasses.dataclass
-class ApplicationStatus:
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class AppStatus:
+    charm: str
+    charm_origin: str
+    charm_name: str
+    charm_rev: int
+    exposed: bool
+
+    base: FormattedBase | None = None
+    charm_channel: str = ''
+    charm_version: str = ''
+    charm_profile: str = ''
+    can_upgrade_to: str = ''
+    scale: int = 0
+    provider_id: str = ''
+    address: str = ''
+    life: str = ''
     app_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    relations: dict[str, list[AppStatusRelation]] = dataclasses.field(default_factory=dict)
+    subordinate_to: list[str] = dataclasses.field(default_factory=list)
     units: dict[str, UnitStatus] = dataclasses.field(default_factory=dict)
+    version: str = ''
+    endpoint_bindings: dict[str, str] = dataclasses.field(default_factory=dict)
 
     @classmethod
-    def from_dict(cls, d):
-        self = cls()
-        self.app_status = StatusInfoContents.from_dict(d.get('application-status') or {})
-        return self
+    def from_dict(cls, d: dict[str, Any]) -> AppStatus:
+        if 'status-error' in d:
+            raise StatusError(d['status-error'])
+        return cls(
+            charm=d['charm'],
+            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            charm_origin=d['charm-origin'],
+            charm_name=d['charm-name'],
+            charm_rev=d['charm-rev'],
+            charm_channel=d.get('charm-channel') or '',
+            charm_version=d.get('charm-version') or '',
+            charm_profile=d.get('charm-profile') or '',
+            can_upgrade_to=d.get('can-upgrade-to') or '',
+            scale=d.get('scale') or 0,
+            provider_id=d.get('provider-id') or '',
+            address=d.get('address') or '',
+            exposed=d['exposed'],
+            life=d.get('life') or '',
+            app_status=(
+                StatusInfoContents.from_dict(d['application-status'])
+                if 'application-status' in d
+                else StatusInfoContents()
+            ),
+            relations=(
+                {k: [AppStatusRelation.from_dict(x) for x in v] for k, v in d['relations'].items()}
+                if 'relations' in d
+                else {}
+            ),
+            subordinate_to=d.get('subordinate-to') or [],
+            units=(
+                {k: UnitStatus.from_dict(v) for k, v in d['units'].items()} if 'units' in d else {}
+            ),
+            version=d.get('version') or '',
+            endpoint_bindings=d.get('endpoint-bindings') or {},
+        )
 
     @property
     def is_active(self) -> bool:
@@ -87,13 +216,489 @@ class ApplicationStatus:
         return self.app_status.current == 'waiting'
 
 
-@dataclasses.dataclass
-class Status:
-    apps: dict[str, ApplicationStatus] = dataclasses.field(default_factory=dict)
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class EntityStatus:
+    current: str = ''
+    message: str = ''
+    since: str = ''
 
     @classmethod
-    def from_dict(cls, d):
-        self = cls()
-        apps = d.get('applications') or {}
-        self.apps = {name: ApplicationStatus.from_dict(status) for name, status in apps.items()}
-        return self
+    def from_dict(cls, d: dict[str, Any]) -> EntityStatus:
+        return cls(
+            current=d.get('current') or '',
+            message=d.get('message') or '',
+            since=d.get('since') or '',
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class UnitStorageAttachment:
+    machine: str = ''
+    location: str = ''
+    life: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> UnitStorageAttachment:
+        return cls(
+            machine=d.get('machine') or '',
+            location=d.get('location') or '',
+            life=d.get('life') or '',
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class StorageAttachments:
+    units: dict[str, UnitStorageAttachment]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> StorageAttachments:
+        return cls(
+            units={k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()},
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class StorageInfo:
+    kind: str
+    status: EntityStatus
+    persistent: bool
+
+    life: str = ''
+    attachments: StorageAttachments | None = None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> StorageInfo:
+        return cls(
+            kind=d['kind'],
+            life=d.get('life') or '',
+            status=EntityStatus.from_dict(d['status']),
+            persistent=d['persistent'],
+            attachments=(
+                StorageAttachments.from_dict(d['attachments']) if 'attachments' in d else None
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class FilesystemAttachment:
+    mount_point: str
+    read_only: bool
+
+    life: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachment:
+        return cls(
+            mount_point=d['mount-point'],
+            read_only=d['read-only'],
+            life=d.get('life') or '',
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class FilesystemAttachments:
+    machines: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
+    containers: dict[str, FilesystemAttachment] = dataclasses.field(default_factory=dict)
+    units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FilesystemAttachments:
+        return cls(
+            machines=(
+                {k: FilesystemAttachment.from_dict(v) for k, v in d['machines'].items()}
+                if 'machines' in d
+                else {}
+            ),
+            containers=(
+                {k: FilesystemAttachment.from_dict(v) for k, v in d['containers'].items()}
+                if 'containers' in d
+                else {}
+            ),
+            units=(
+                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                if 'units' in d
+                else {}
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class FilesystemInfo:
+    Attachments: FilesystemAttachments
+    size: int
+
+    provider_id: str = ''
+    volume: str = ''
+    storage: str = ''
+    pool: str = ''
+    life: str = ''
+    status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> FilesystemInfo:
+        return cls(
+            provider_id=d.get('provider-id') or '',
+            volume=d.get('volume') or '',
+            storage=d.get('storage') or '',
+            Attachments=FilesystemAttachments.from_dict(d['Attachments']),
+            pool=d.get('pool') or '',
+            size=d['size'],
+            life=d.get('life') or '',
+            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class VolumeAttachment:
+    read_only: bool
+
+    device: str = ''
+    device_link: str = ''
+    bus_address: str = ''
+    life: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachment:
+        return cls(
+            device=d.get('device') or '',
+            device_link=d.get('device-link') or '',
+            bus_address=d.get('bus-address') or '',
+            read_only=d['read-only'],
+            life=d.get('life') or '',
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class VolumeAttachments:
+    machines: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
+    containers: dict[str, VolumeAttachment] = dataclasses.field(default_factory=dict)
+    units: dict[str, UnitStorageAttachment] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> VolumeAttachments:
+        return cls(
+            machines=(
+                {k: VolumeAttachment.from_dict(v) for k, v in d['machines'].items()}
+                if 'machines' in d
+                else {}
+            ),
+            containers=(
+                {k: VolumeAttachment.from_dict(v) for k, v in d['containers'].items()}
+                if 'containers' in d
+                else {}
+            ),
+            units=(
+                {k: UnitStorageAttachment.from_dict(v) for k, v in d['units'].items()}
+                if 'units' in d
+                else {}
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class VolumeInfo:
+    size: int
+    persistent: bool
+
+    provider_id: str = ''
+    storage: str = ''
+    attachments: VolumeAttachments = dataclasses.field(default_factory=VolumeAttachments)
+    pool: str = ''
+    hardware_id: str = ''
+    wwn: str = ''
+    life: str = ''
+    status: EntityStatus = dataclasses.field(default_factory=EntityStatus)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> VolumeInfo:
+        return cls(
+            provider_id=d.get('provider-id') or '',
+            storage=d.get('storage') or '',
+            attachments=(
+                VolumeAttachments.from_dict(d['attachments'])
+                if 'attachments' in d
+                else VolumeAttachments()
+            ),
+            pool=d.get('pool') or '',
+            hardware_id=d.get('hardware-id') or '',
+            wwn=d.get('wwn') or '',
+            size=d['size'],
+            persistent=d['persistent'],
+            life=d.get('life') or '',
+            status=EntityStatus.from_dict(d['status']) if 'status' in d else EntityStatus(),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CombinedStorage:
+    storage: dict[str, StorageInfo] = dataclasses.field(default_factory=dict)
+    filesystems: dict[str, FilesystemInfo] = dataclasses.field(default_factory=dict)
+    volumes: dict[str, VolumeInfo] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> CombinedStorage:
+        return cls(
+            storage=(
+                {k: StorageInfo.from_dict(v) for k, v in d['storage'].items()}
+                if 'storage' in d
+                else {}
+            ),
+            filesystems=(
+                {k: FilesystemInfo.from_dict(v) for k, v in d['filesystems'].items()}
+                if 'filesystems' in d
+                else {}
+            ),
+            volumes=(
+                {k: VolumeInfo.from_dict(v) for k, v in d['volumes'].items()}
+                if 'volumes' in d
+                else {}
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ControllerStatus:
+    timestamp: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ControllerStatus:
+        return cls(
+            timestamp=d.get('timestamp') or '',
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class LxdProfileContents:
+    config: dict[str, str]
+    description: str
+    devices: dict[str, dict[str, str]]
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LxdProfileContents:
+        return cls(
+            config=d['config'],
+            description=d['description'],
+            devices=d['devices'],
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class NetworkInterface:
+    ip_addresses: list[str]
+    mac_address: str
+    is_up: bool
+
+    gateway: str = ''
+    dns_nameservers: list[str] = dataclasses.field(default_factory=list)
+    space: str = ''
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> NetworkInterface:
+        return cls(
+            ip_addresses=d['ip-addresses'],
+            mac_address=d['mac-address'],
+            gateway=d.get('gateway') or '',
+            dns_nameservers=d.get('dns-nameservers') or [],
+            space=d.get('space') or '',
+            is_up=d['is-up'],
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class MachineStatus:
+    juju_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    hostname: str = ''
+    dns_name: str = ''
+    ip_addresses: list[str] = dataclasses.field(default_factory=list)
+    instance_id: str = ''
+    display_name: str = ''
+    machine_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    modification_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    base: FormattedBase | None = None
+    network_interfaces: dict[str, NetworkInterface] = dataclasses.field(default_factory=dict)
+    containers: dict[str, MachineStatus] = dataclasses.field(default_factory=dict)
+    constraints: str = ''
+    hardware: str = ''
+    controller_member_status: str = ''
+    ha_primary: bool = False
+    lxd_profiles: dict[str, LxdProfileContents] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MachineStatus:
+        if 'status-error' in d:
+            raise StatusError(d['status-error'])
+        return cls(
+            juju_status=(
+                StatusInfoContents.from_dict(d['juju-status'])
+                if 'juju-status' in d
+                else StatusInfoContents()
+            ),
+            hostname=d.get('hostname') or '',
+            dns_name=d.get('dns-name') or '',
+            ip_addresses=d.get('ip-addresses') or [],
+            instance_id=d.get('instance-id') or '',
+            display_name=d.get('display-name') or '',
+            machine_status=(
+                StatusInfoContents.from_dict(d['machine-status'])
+                if 'machine-status' in d
+                else StatusInfoContents()
+            ),
+            modification_status=(
+                StatusInfoContents.from_dict(d['modification-status'])
+                if 'modification-status' in d
+                else StatusInfoContents()
+            ),
+            base=FormattedBase.from_dict(d['base']) if 'base' in d else None,
+            network_interfaces=(
+                {k: NetworkInterface.from_dict(v) for k, v in d['network-interfaces'].items()}
+                if 'network-interfaces' in d
+                else {}
+            ),
+            containers=(
+                {k: MachineStatus.from_dict(v) for k, v in d['containers'].items()}
+                if 'containers' in d
+                else {}
+            ),
+            constraints=d.get('constraints') or '',
+            hardware=d.get('hardware') or '',
+            controller_member_status=d.get('controller-member-status') or '',
+            ha_primary=d.get('ha-primary') or False,
+            lxd_profiles=(
+                {k: LxdProfileContents.from_dict(v) for k, v in d['lxd-profiles'].items()}
+                if 'lxd-profiles' in d
+                else {}
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ModelStatus:
+    name: str
+    type: str
+    controller: str
+    cloud: str
+    version: str
+
+    region: str = ''
+    upgrade_available: str = ''
+    model_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ModelStatus:
+        return cls(
+            name=d['name'],
+            type=d['type'],
+            controller=d['controller'],
+            cloud=d['cloud'],
+            region=d.get('region') or '',
+            version=d['version'],
+            upgrade_available=d.get('upgrade-available') or '',
+            model_status=(
+                StatusInfoContents.from_dict(d['model-status'])
+                if 'model-status' in d
+                else StatusInfoContents()
+            ),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class RemoteEndpoint:
+    interface: str
+    role: str
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RemoteEndpoint:
+        return cls(
+            interface=d['interface'],
+            role=d['role'],
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class OfferStatus:
+    app: str
+    endpoints: dict[str, RemoteEndpoint]
+
+    charm: str = ''
+    total_connected_count: int = 0
+    active_connected_count: int = 0
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> OfferStatus:
+        if 'status-error' in d:
+            raise StatusError(d['status-error'])
+        return cls(
+            app=d['application'],
+            charm=d.get('charm') or '',
+            total_connected_count=d.get('total-connected-count') or 0,
+            active_connected_count=d.get('active-connected-count') or 0,
+            endpoints={k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()},
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class RemoteAppStatus:
+    url: str
+
+    endpoints: dict[str, RemoteEndpoint] = dataclasses.field(default_factory=dict)
+    life: str = ''
+    app_status: StatusInfoContents = dataclasses.field(default_factory=StatusInfoContents)
+    relations: dict[str, list[str]] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> RemoteAppStatus:
+        if 'status-error' in d:
+            raise StatusError(d['status-error'])
+        return cls(
+            url=d['url'],
+            endpoints=(
+                {k: RemoteEndpoint.from_dict(v) for k, v in d['endpoints'].items()}
+                if 'endpoints' in d
+                else {}
+            ),
+            life=d.get('life') or '',
+            app_status=(
+                StatusInfoContents.from_dict(d['application-status'])
+                if 'application-status' in d
+                else StatusInfoContents()
+            ),
+            relations=d.get('relations') or {},
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Status:
+    model: ModelStatus
+    machines: dict[str, MachineStatus]
+    apps: dict[str, AppStatus]
+
+    app_endpoints: dict[str, RemoteAppStatus] = dataclasses.field(default_factory=dict)
+    offers: dict[str, OfferStatus] = dataclasses.field(default_factory=dict)
+    storage: CombinedStorage = dataclasses.field(default_factory=CombinedStorage)
+    controller: ControllerStatus = dataclasses.field(default_factory=ControllerStatus)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> Status:
+        return cls(
+            model=ModelStatus.from_dict(d['model']),
+            machines={k: MachineStatus.from_dict(v) for k, v in d['machines'].items()},
+            apps={k: AppStatus.from_dict(v) for k, v in d['applications'].items()},
+            app_endpoints=(
+                {k: RemoteAppStatus.from_dict(v) for k, v in d['application-endpoints'].items()}
+                if 'application-endpoints' in d
+                else {}
+            ),
+            offers=(
+                {k: OfferStatus.from_dict(v) for k, v in d['offers'].items()}
+                if 'offers' in d
+                else {}
+            ),
+            storage=(
+                CombinedStorage.from_dict(d['storage']) if 'storage' in d else CombinedStorage()
+            ),
+            controller=(
+                ControllerStatus.from_dict(d['controller'])
+                if 'controller' in d
+                else ControllerStatus()
+            ),
+        )

--- a/jubilant/types.py
+++ b/jubilant/types.py
@@ -5,6 +5,35 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+__all__ = [
+    'AppStatus',
+    'AppStatusRelation',
+    'CombinedStorage',
+    'ControllerStatus',
+    'EntityStatus',
+    'FilesystemAttachment',
+    'FilesystemAttachments',
+    'FilesystemInfo',
+    'FormattedBase',
+    'LxdProfileContents',
+    'MachineStatus',
+    'ModelStatus',
+    'NetworkInterface',
+    'OfferStatus',
+    'RemoteAppStatus',
+    'RemoteEndpoint',
+    'Status',
+    'StatusError',
+    'StatusInfoContents',
+    'StorageAttachments',
+    'StorageInfo',
+    'UnitStatus',
+    'UnitStorageAttachment',
+    'VolumeAttachment',
+    'VolumeAttachments',
+    'VolumeInfo',
+]
+
 
 class StatusError(Exception):
     """Raised when "juju status" returns a status-error for certain types."""

--- a/jubilant/types.py
+++ b/jubilant/types.py
@@ -706,6 +706,8 @@ class RemoteAppStatus:
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class Status:
+    """Parsed version of the status object returned by "juju status --format=json"."""
+
     model: ModelStatus
     machines: dict[str, MachineStatus]
     apps: dict[str, AppStatus]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,10 @@ convention = "google"
 builtins-ignorelist = ["id", "min", "map", "range", "type", "input", "format"]
 
 [tool.ruff.lint.per-file-ignores]
+"jubilant/types.py" = [
+    # Missing docstring in public class
+    "D101",
+]
 "test/*" = [
     # All documentation linting.
     "D",


### PR DESCRIPTION
These come from the Go generator in https://github.com/benhoyt/juju/pull/2 (which now has the `is_*` methods added to `UnitStatus` and `AppStatus`).

Also renames `ApplicationStatus` to `AppStatus` for consistency (we're abbreviating "application" to "app" everywhere).

Fixes #17.