### PR TITLE
ci: single ci.yaml, fmt -> format, tweak lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Jubilant CI
 
 on:
   push:
@@ -30,7 +30,7 @@ jobs:
       - name: Run static type checks
         run: make static
 
-  test:
+  unit:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
   workflow_call:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Jubilant CI
+name: CI
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ fix:
 	uv run ruff check --fix
 
 # Format the Python code
-.PHONY: fmt
-fmt:
+.PHONY: format
+format:
 	uv run ruff format
 
 # Run integration tests (slow, require real Juju)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ integration:
 .PHONY: lint
 lint:
 	uv run ruff check
-	uv run ruff format --check
+	uv run ruff format --diff
 
 # Check static types
 .PHONY: static

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable
 
 from .statustypes import Status
 
-logger =  logging.getLogger('jubilant')
+logger = logging.getLogger('jubilant')
 
 
 class CLIError(subprocess.CalledProcessError):
@@ -73,9 +73,9 @@ class Juju:
             f'wait_timeout={self.wait_timeout}',
             f'cli_binary={self.cli_binary!r}',
         ]
-        return 'Juju({", ".join(args)})'
+        return f'Juju({", ".join(args)})'
 
-    def cli(self, *args: str, include_model: bool = True) -> bytes:
+    def cli(self, *args: str, include_model: bool = True) -> str:
         """Run a Juju CLI command and return its standard output.
 
         Args:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Iterable
 
 from .statustypes import Status
 
-logger = logging.getLogger('jubilant')
+logger =  logging.getLogger('jubilant')
 
 
 class CLIError(subprocess.CalledProcessError):
@@ -73,9 +73,9 @@ class Juju:
             f'wait_timeout={self.wait_timeout}',
             f'cli_binary={self.cli_binary!r}',
         ]
-        return f'Juju({", ".join(args)})'
+        return 'Juju({", ".join(args)})'
 
-    def cli(self, *args: str, include_model: bool = True) -> str:
+    def cli(self, *args: str, include_model: bool = True) -> bytes:
         """Run a Juju CLI command and return its standard output.
 
         Args:


### PR DESCRIPTION
I actually introduced GitHub Actions in https://github.com/canonical/jubilant/pull/32 and was going to review there, but GitHub Actions didn't run there because the `.github` directory must exist on `main` first. So I just merged that, and I'm requesting review of the actions YAML on this PR:

**[.github/workflows/tests-unit.yaml](https://github.com/canonical/jubilant/blob/main/.github/workflows/tests-unit.yaml)**

- Example of failing run: https://github.com/canonical/jubilant/actions/runs/13447290839
- Example of succeeding run: https://github.com/canonical/jubilant/actions/runs/13447324561

This PR also changes:

- `tests-unit.yaml` -> `ci.yaml` (one file, at least for now)
- `make fmt` -> `make format`
- `make lint` prints the diff when running the Ruff format check -- when it checks the formatting it prints the diff for better diagnosis

Fixes #19.