### PR TITLE
feat: add compact Status.__str__ like "juju status" tabular output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ jubilant.egg-info
 /docs/_build
 /.idea
 /t.py
+/.coverage

--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ static:
 # Run quick unit tests
 .PHONY: unit
 unit:
-	uv run pytest test/unit
+	uv run pytest test/unit --cov=jubilant

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 # Run all quick, local commands
 .PHONY: all
-all: fmt lint static unit
+all: format lint static unit
 
 # Build documentation
 .PHONY: docs

--- a/jubilant/_helpers.py
+++ b/jubilant/_helpers.py
@@ -14,17 +14,6 @@ def all_active(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _all_statuses_are('active', status, apps)
 
 
-def all_error(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether all applications or units in *status* are in "error" status.
-
-    Args:
-        status: The status object being tested.
-        apps: An optional list of application names. If provided, only these applications
-            (and their units) are tested.
-    """
-    return _all_statuses_are('error', status, apps)
-
-
 def all_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
     """Report whether all applications or units in *status* are in "blocked" status.
 
@@ -34,6 +23,17 @@ def all_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
             (and their units) are tested.
     """
     return _all_statuses_are('blocked', status, apps)
+
+
+def all_error(status: Status, apps: Iterable[str] | None = None) -> bool:
+    """Report whether all applications or units in *status* are in "error" status.
+
+    Args:
+        status: The status object being tested.
+        apps: An optional list of application names. If provided, only these applications
+            (and their units) are tested.
+    """
+    return _all_statuses_are('error', status, apps)
 
 
 def all_maintenance(status: Status, apps: Iterable[str] | None = None) -> bool:
@@ -69,17 +69,6 @@ def any_active(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _any_status_is('active', status, apps)
 
 
-def any_error(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether any application or unit in *status* is in "error" status.
-
-    Args:
-        status: The status object being tested.
-        apps: An optional list of application names. If provided, only these applications
-            (and their units) are tested.
-    """
-    return _any_status_is('error', status, apps)
-
-
 def any_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
     """Report whether any application or unit in *status* is in "blocked" status.
 
@@ -89,6 +78,17 @@ def any_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
             (and their units) are tested.
     """
     return _any_status_is('blocked', status, apps)
+
+
+def any_error(status: Status, apps: Iterable[str] | None = None) -> bool:
+    """Report whether any application or unit in *status* is in "error" status.
+
+    Args:
+        status: The status object being tested.
+        apps: An optional list of application names. If provided, only these applications
+            (and their units) are tested.
+    """
+    return _any_status_is('error', status, apps)
 
 
 def any_maintenance(status: Status, apps: Iterable[str] | None = None) -> bool:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -60,7 +60,7 @@ class Juju:
         self,
         *,
         model: str | None = None,
-        wait_timeout: float = 3 * 60.0,
+        wait_timeout: float = 3 * 60,
         cli_binary: str | os.PathLike | None = None,
     ):
         self.model = model
@@ -87,7 +87,7 @@ class Juju:
             args = (args[0], '--model', self.model) + args[1:]
         try:
             process = subprocess.run(
-                [self.cli_binary, *args], check=True, capture_output=True, encoding='UTF-8'
+                [self.cli_binary, *args], check=True, capture_output=True, encoding='utf-8'
             )
         except subprocess.CalledProcessError as e:
             raise CLIError(e.returncode, e.cmd, e.stdout, e.stderr) from None
@@ -134,7 +134,7 @@ class Juju:
         self,
         model: str,
         *,
-        force=False,
+        force: bool = False,
     ) -> None:
         """Terminate all machines (or containers) and resources for a model.
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -60,7 +60,7 @@ class Juju:
         self,
         *,
         model: str | None = None,
-        wait_timeout: float = 3 * 60,
+        wait_timeout: float = 3 * 60.0,
         cli_binary: str | os.PathLike | None = None,
     ):
         self.model = model

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -138,8 +138,8 @@ class Juju:
     ) -> None:
         """Terminate all machines (or containers) and resources for a model.
 
-        Also sets this instance's :attr:`model` to None, meaning use the current Juju model for
-        subsequent commands.
+        If the given model is this instance's model, also sets this instance's
+        :attr:`model` to None.
 
         Args:
             model: Name of model to destroy.
@@ -149,7 +149,8 @@ class Juju:
         if force:
             args.append('--force')
         self.cli(*args, include_model=False)
-        self.model = None
+        if model == self.model:
+            self.model = None
 
     def deploy(
         self,

--- a/jubilant/_status.py
+++ b/jubilant/_status.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from . import statustypes
+
+
+def _status_str(self: statustypes.Status) -> str:
+    # Implementation of Status.__str__ is here to avoid it having to be in the
+    # generated code. The parameter name is "self" as it would be if defined
+    # in Status.__str__ directly.
+
+    writes = []
+
+    notes = ''
+    if self.model.model_status.message:
+        notes = self.model.model_status.message
+    elif self.model.upgrade_available:
+        notes = f'upgrade available: {self.model.upgrade_available}'
+    _format_rows(
+        writes.append,
+        [
+            ['Model', 'Controller', 'Cloud/Region', 'Version', 'Timestamp', 'Notes'],
+            [
+                self.model.name,
+                self.model.controller,
+                self.model.cloud + ('/' + self.model.region if self.model.region else ''),
+                self.model.version,
+                self.controller.timestamp,
+                notes,
+            ],
+        ],
+    )
+
+    # TODO: need remote applications / app_endpoints
+
+    app_rows = [
+        [
+            'App',
+            'Version',
+            'Status',
+            'Scale',
+            'Charm',
+            'Channel',
+            'Rev',
+            'Address',
+            'Exposed',
+            'Message',
+        ]
+    ]
+    unit_rows = [
+        [
+            'Unit',
+            'Workload',
+            'Agent',
+            'Machine',
+            'Address' if self.model.type == 'caas' else 'Public address',
+            'Ports',
+            'Message',
+        ],
+    ]
+    relation_rows = [
+        ['Integration provider', 'Requirer', 'Interface', 'Type', 'Message'],
+    ]
+    for app_name, app in sorted(self.apps.items()):
+        app_rows.append(
+            [
+                app_name,
+                app.version.split('\n', maxsplit=1)[0],
+                app.app_status.current,
+                str(app.scale),  # TODO: only for CAAS, see formattedStatus.applicationScale
+                app.charm_name,
+                app.charm_channel,
+                str(app.charm_rev),
+                app.address,
+                'yes' if app.exposed else 'no',
+                app.app_status.message,
+            ]
+        )
+        for unit_name, unit in sorted(app.units.items()):
+            unit_rows.append(
+                [
+                    unit_name + '*' if unit.leader else unit_name,
+                    unit.workload_status.current,
+                    unit.juju_status.current,
+                    '' if self.model.type == 'caas' else unit.machine,
+                    unit.address if self.model.type == 'caas' else unit.public_address,
+                    ','.join(unit.open_ports),  # TODO: not like Juju
+                    unit.juju_status.message,  # TODO: not quite correct, see Juju
+                ]
+            )
+
+    machine_rows = [['Machine', 'State', 'Address', 'Inst id', 'Base', 'AZ', 'Message']]
+    if self.model.type != 'caas' and self.machines:
+        for name, machine in sorted(self.machines.items()):
+            status = machine.juju_status.current
+            message = machine.machine_status.message
+            if machine.modification_status.current == 'error':
+                status = machine.modification_status.current
+                message = machine.modification_status.message
+            machine_rows.append(
+                [
+                    name,
+                    status,
+                    machine.dns_name,
+                    machine.display_name or machine.instance_id,
+                    machine.base.name + '@' + machine.base.channel if machine.base else '',
+                    'TODO:az',
+                    message,
+                ]
+            )
+
+    if len(app_rows) > 1:
+        writes.append('\n')
+        _format_rows(writes.append, app_rows)
+    if len(unit_rows) > 1:
+        writes.append('\n')
+        _format_rows(writes.append, unit_rows)
+    if len(machine_rows) > 1:
+        writes.append('\n')
+        _format_rows(writes.append, machine_rows)
+    if len(relation_rows) > 1:
+        writes.append('\n')
+        _format_rows(writes.append, relation_rows)
+
+    return ''.join(writes)
+
+
+def _format_rows(write: Callable, rows: list[list[str]]):
+    widths = [0] * len(rows[0])
+    for col in range(len(rows[0])):
+        widths[col] = max(len(row[col]) for row in rows)
+    for row in rows:
+        for col, value in enumerate(row):
+            padding = 2 if col < len(row) - 1 else 0
+            write(value.ljust(widths[col] + padding))
+        write('\n')

--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+try:
+    # Real implementation lives in another file to avoid having to include and
+    # maintain this in the Juju code generator.
+    from . import _status
+except ImportError:
+    # So that this module can be imported outside this package (in the context
+    # of the Juju code generator).
+    _status = None
+
 __all__ = [
     'AppStatus',
     'AppStatusRelation',
@@ -742,3 +751,9 @@ class Status:
                 else ControllerStatus()
             ),
         )
+
+    def __str__(self):
+        """Return a "juju status"-style tabular representation of this status."""
+        if _status is None:
+            return super().__str__()
+        return _status._status_str(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dynamic = ["version"]
 dev = [
     "pyright==1.1.394",
     "pytest==8.3.4",
+    "pytest-cov==6.0.0",
     "ruff==0.9.6",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ builtins-ignorelist = ["id", "min", "map", "range", "type", "input", "format"]
 "test/*" = [
     # All documentation linting.
     "D",
+    # Line too long
+    "E501",
 ]
 
 [tool.pyright]

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -11,3 +11,4 @@ def run() -> Generator[mocks.Run, None, None]:
     run_mock = mocks.Run()
     with unittest.mock.patch('subprocess.run', run_mock):
         yield run_mock
+    assert run_mock.call_count >= 1, 'subprocess.run not called'

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 @pytest.fixture
 def run() -> Generator[mocks.Run, None, None]:
+    """Pytest fixture that patches subprocess.run with a mocks.Run instance."""
     run_mock = mocks.Run()
     with unittest.mock.patch('subprocess.run', run_mock):
         yield run_mock

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,5 +1,5 @@
-import unittest.mock
 from collections.abc import Generator
+from unittest import mock
 
 import mocks
 import pytest
@@ -7,8 +7,19 @@ import pytest
 
 @pytest.fixture
 def run() -> Generator[mocks.Run, None, None]:
-    """Pytest fixture that patches subprocess.run with a mocks.Run instance."""
+    """Pytest fixture that patches subprocess.run with mocks.Run."""
     run_mock = mocks.Run()
-    with unittest.mock.patch('subprocess.run', run_mock):
+    with mock.patch('subprocess.run', run_mock):
         yield run_mock
     assert run_mock.call_count >= 1, 'subprocess.run not called'
+
+
+@pytest.fixture
+def time() -> Generator[mocks.Time, None, None]:
+    """Pytest fixture that patches time.monotonic and time.sleep with mocks.Time."""
+    time_mock = mocks.Time()
+    with (
+        mock.patch('time.monotonic', time_mock.monotonic),
+        mock.patch('time.sleep', time_mock.sleep),
+    ):
+        yield time_mock

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,0 +1,12 @@
+import unittest.mock
+from collections.abc import Generator
+
+import mocks
+import pytest
+
+
+@pytest.fixture
+def run() -> Generator[mocks.Run, None, None]:
+    run_mock = mocks.Run()
+    with unittest.mock.patch('subprocess.run', run_mock):
+        yield run_mock

--- a/test/unit/mocks.py
+++ b/test/unit/mocks.py
@@ -2,11 +2,22 @@ import subprocess
 
 
 class Run:
+    """Mock for subprocess.run.
+
+    When subprocess.run is called, the mock returns a subprocess.CompletedProcess
+    instance with data passed to :meth:`handle` for those command-line arguments.
+    Or, if returncode is nonzero, it raises a subprocess.CalledProcessError.
+
+    This also asserts that the correct keyword args are passed to subprocess.run,
+    for example check=True.
+    """
+
     def __init__(self):
-        self.commands = {}
+        self._commands = {}
 
     def handle(self, args: list[str], returncode: int = 0, stdout: str = '', stderr: str = ''):
-        self.commands[tuple(args)] = (returncode, stdout, stderr)
+        """Handle specified command-line args with the given return code, stdout, and stderr."""
+        self._commands[tuple(args)] = (returncode, stdout, stderr)
 
     def __call__(
         self,
@@ -18,8 +29,8 @@ class Run:
         assert check is True
         assert capture_output is True
         assert encoding == 'utf-8'
-        assert tuple(args) in self.commands, f'unhandled command {args}'
-        returncode, stdout, stderr = self.commands[tuple(args)]
+        assert tuple(args) in self._commands, f'unhandled command {args}'
+        returncode, stdout, stderr = self._commands[tuple(args)]
         if returncode != 0:
             raise subprocess.CalledProcessError(
                 returncode=returncode,

--- a/test/unit/mocks.py
+++ b/test/unit/mocks.py
@@ -14,6 +14,7 @@ class Run:
 
     def __init__(self):
         self._commands = {}
+        self.call_count = 0
 
     def handle(self, args: list[str], returncode: int = 0, stdout: str = '', stderr: str = ''):
         """Handle specified command-line args with the given return code, stdout, and stderr."""
@@ -30,6 +31,8 @@ class Run:
         assert capture_output is True
         assert encoding == 'utf-8'
         assert tuple(args) in self._commands, f'unhandled command {args}'
+
+        self.call_count += 1
         returncode, stdout, stderr = self._commands[tuple(args)]
         if returncode != 0:
             raise subprocess.CalledProcessError(

--- a/test/unit/mocks.py
+++ b/test/unit/mocks.py
@@ -47,3 +47,20 @@ class Run:
             stdout=stdout,
             stderr=stderr,
         )
+
+
+class Time:
+    """Mock for time.monotonic and time.sleep.
+
+    This is very simplistic: time.monotonic() starts out at 0, and every time
+    time.sleep(x) is called, it increases by x.
+    """
+
+    def __init__(self):
+        self._monotonic = 0
+
+    def monotonic(self) -> float:
+        return self._monotonic
+
+    def sleep(self, seconds: float):
+        self._monotonic += seconds

--- a/test/unit/mocks.py
+++ b/test/unit/mocks.py
@@ -1,0 +1,35 @@
+import subprocess
+
+
+class Run:
+    def __init__(self):
+        self.commands = {}
+
+    def handle(self, args: list[str], returncode: int = 0, stdout: str = '', stderr: str = ''):
+        self.commands[tuple(args)] = (returncode, stdout, stderr)
+
+    def __call__(
+        self,
+        args: list[str],
+        check: bool = False,
+        capture_output: bool = False,
+        encoding: str | None = None,
+    ) -> subprocess.CompletedProcess:
+        assert check is True
+        assert capture_output is True
+        assert encoding == 'utf-8'
+        assert tuple(args) in self.commands, f'unhandled command {args}'
+        returncode, stdout, stderr = self.commands[tuple(args)]
+        if returncode != 0:
+            raise subprocess.CalledProcessError(
+                returncode=returncode,
+                cmd=args,
+                output=stdout,
+                stderr=stderr,
+            )
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )

--- a/test/unit/test_add_model.py
+++ b/test/unit/test_add_model.py
@@ -1,0 +1,35 @@
+import mocks
+
+import jubilant
+
+
+def test_defaults(run: mocks.Run):
+    run.handle(['juju', 'add-model', 'new'])
+    juju = jubilant.Juju(model='initial')
+
+    juju.add_model('new')
+
+    assert juju.model == 'new'
+
+
+def test_args(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'add-model',
+            'm',
+            '--controller',
+            'c',
+            '--config',
+            'x=true',
+            '--config',
+            'y=1',
+            '--config',
+            'z=ss',
+        ]
+    )
+    juju = jubilant.Juju()
+
+    juju.add_model('m', controller='c', config={'x': True, 'y': 1, 'z': 'ss'})
+
+    assert juju.model == 'm'

--- a/test/unit/test_add_model.py
+++ b/test/unit/test_add_model.py
@@ -12,7 +12,7 @@ def test_defaults(run: mocks.Run):
     assert juju.model == 'new'
 
 
-def test_args(run: mocks.Run):
+def test_all_args(run: mocks.Run):
     run.handle(
         [
             'juju',

--- a/test/unit/test_basic.py
+++ b/test/unit/test_basic.py
@@ -1,6 +1,0 @@
-import jubilant
-
-
-def test_repr():
-    juju = jubilant.Juju()
-    assert repr(juju) == "Juju(model=None, wait_timeout=180.0, cli_binary='juju')"

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -28,6 +28,14 @@ def test_error(run: mocks.Run):
     assert exc.cmd == ['juju', 'error']
     assert exc.stdout == 'OUT'
     assert exc.stderr == 'ERR'
+    assert (
+        str(exc)
+        == """Command '['juju', 'error']' returned non-zero exit status 3.
+Stdout:
+OUT
+Stderr:
+ERR"""
+    )
 
 
 def test_include_model_no_model(run: mocks.Run):

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,0 +1,30 @@
+import subprocess
+
+import mocks
+import pytest
+
+import jubilant
+
+
+def test_cli_success(run: mocks.Run):
+    run.handle(['juju', 'bootstrap', 'microk8s'], stdout='bootstrapped\n')
+    juju = jubilant.Juju()
+
+    stdout = juju.cli('bootstrap', 'microk8s')
+
+    assert stdout == 'bootstrapped\n'
+
+
+def test_cli_error(run: mocks.Run):
+    run.handle(['juju', 'error'], returncode=3, stdout='OUT', stderr='ERR')
+    juju = jubilant.Juju()
+
+    with pytest.raises(jubilant.CLIError) as excinfo:
+        juju.cli('error')
+
+    exc = excinfo.value
+    assert isinstance(exc, subprocess.CalledProcessError)
+    assert exc.returncode == 3
+    assert exc.cmd == ['juju', 'error']
+    assert exc.stdout == 'OUT'
+    assert exc.stderr == 'ERR'

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 import jubilant
 
 
-def test_cli_success(run: mocks.Run):
+def test_success(run: mocks.Run):
     run.handle(['juju', 'bootstrap', 'microk8s'], stdout='bootstrapped\n')
     juju = jubilant.Juju()
 
@@ -15,7 +15,7 @@ def test_cli_success(run: mocks.Run):
     assert stdout == 'bootstrapped\n'
 
 
-def test_cli_error(run: mocks.Run):
+def test_error(run: mocks.Run):
     run.handle(['juju', 'error'], returncode=3, stdout='OUT', stderr='ERR')
     juju = jubilant.Juju()
 
@@ -28,3 +28,39 @@ def test_cli_error(run: mocks.Run):
     assert exc.cmd == ['juju', 'error']
     assert exc.stdout == 'OUT'
     assert exc.stderr == 'ERR'
+
+
+def test_include_model_no_model(run: mocks.Run):
+    run.handle(['juju', 'test'], stdout='OUT')
+    juju = jubilant.Juju()
+
+    stdout = juju.cli('test')
+
+    assert stdout == 'OUT'
+
+
+def test_include_model_with_model(run: mocks.Run):
+    run.handle(['juju', 'test', '--model', 'mdl'], stdout='OUT')
+    juju = jubilant.Juju(model='mdl')
+
+    stdout = juju.cli('test')
+
+    assert stdout == 'OUT'
+
+
+def test_exclude_model_no_model(run: mocks.Run):
+    run.handle(['juju', 'test'], stdout='OUT')
+    juju = jubilant.Juju()
+
+    stdout = juju.cli('test', include_model=False)
+
+    assert stdout == 'OUT'
+
+
+def test_exclude_model_with_model(run: mocks.Run):
+    run.handle(['juju', 'test'], stdout='OUT')
+    juju = jubilant.Juju(model='mdl')
+
+    stdout = juju.cli('test', include_model=False)
+
+    assert stdout == 'OUT'

--- a/test/unit/test_deploy.py
+++ b/test/unit/test_deploy.py
@@ -1,0 +1,79 @@
+import mocks
+
+import jubilant
+
+
+def test_defaults_no_model(run: mocks.Run):
+    run.handle(['juju', 'deploy', 'xyz'])
+    juju = jubilant.Juju()
+
+    juju.deploy('xyz')
+
+
+def test_defaults_with_model(run: mocks.Run):
+    run.handle(['juju', 'deploy', '--model', 'mdl', 'xyz'])
+    juju = jubilant.Juju(model='mdl')
+
+    juju.deploy('xyz')
+
+
+def test_all_args(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'deploy',
+            'charm',
+            'app',
+            '--attach-storage',
+            'stg',
+            '--base',
+            'ubuntu@22.04',
+            '--channel',
+            'latest/edge',
+            '--config',
+            'x=true',
+            '--config',
+            'y=1',
+            '--config',
+            'z=ss',
+            '--constraints',
+            'mem=8G',
+            '--force',
+            '--num-units',
+            '3',
+            '--resource',
+            'bin=/path',
+            '--revision',
+            '42',
+            '--storage',
+            'data=tmpfs,1G',
+            '--to',
+            'lxd:25',
+            '--trust',
+        ]
+    )
+    juju = jubilant.Juju()
+
+    juju.deploy(
+        'charm',
+        'app',
+        attach_storage='stg',
+        base='ubuntu@22.04',
+        channel='latest/edge',
+        config={'x': True, 'y': 1, 'z': 'ss'},
+        constraints={'mem': '8G'},
+        force=True,
+        num_units=3,
+        resource={'bin': '/path'},
+        revision=42,
+        storage={'data': 'tmpfs,1G'},
+        to='lxd:25',
+        trust=True,
+    )
+
+
+def test_list_args(run: mocks.Run):
+    run.handle(['juju', 'deploy', 'charm', '--attach-storage', 'stg1,stg2', '--to', 'to1,to2'])
+    juju = jubilant.Juju()
+
+    juju.deploy('charm', attach_storage=['stg1', 'stg2'], to=['to1', 'to2'])

--- a/test/unit/test_destroy_model.py
+++ b/test/unit/test_destroy_model.py
@@ -1,0 +1,30 @@
+import mocks
+
+import jubilant
+
+
+def test_destroy_this(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'initial', '--no-prompt'])
+    juju = jubilant.Juju(model='initial')
+
+    juju.destroy_model('initial')
+
+    assert juju.model is None
+
+
+def test_destroy_other(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'other', '--no-prompt'])
+    juju = jubilant.Juju(model='initial')
+
+    juju.destroy_model('other')
+
+    assert juju.model == 'initial'
+
+
+def test_force(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'bad', '--no-prompt', '--force'])
+    juju = jubilant.Juju()
+
+    juju.destroy_model('bad', force=True)
+
+    assert juju.model is None

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -1,0 +1,248 @@
+import copy
+import json
+from collections.abc import Callable
+
+import pytest
+from test_status import MINIMAL_STATUS, SNAPPASS_JSON
+
+import jubilant
+
+
+@pytest.mark.parametrize(
+    'all_func',
+    [
+        jubilant.all_active,
+        jubilant.all_blocked,
+        jubilant.all_error,
+        jubilant.all_maintenance,
+        jubilant.all_waiting,
+    ],
+)
+def test_all_no_apps(all_func: Callable):
+    # Just like Python's all(), all_* helpers return True if no apps
+    assert all_func(MINIMAL_STATUS)
+    assert all_func(MINIMAL_STATUS, [])
+
+
+@pytest.mark.parametrize(
+    'any_func',
+    [
+        jubilant.any_active,
+        jubilant.any_blocked,
+        jubilant.any_error,
+        jubilant.any_maintenance,
+        jubilant.any_waiting,
+    ],
+)
+def test_any_no_apps(any_func: Callable):
+    # Just like Python's any(), any_* helpers return False if no apps
+    assert not any_func(MINIMAL_STATUS)
+    assert not any_func(MINIMAL_STATUS, [])
+
+
+@pytest.mark.parametrize(
+    'all_func,expected,unexpected',
+    [
+        (jubilant.all_active, 'active', 'error'),
+        (jubilant.all_blocked, 'blocked', 'error'),
+        (jubilant.all_error, 'error', 'active'),
+        (jubilant.all_maintenance, 'maintenance', 'error'),
+        (jubilant.all_waiting, 'waiting', 'error'),
+    ],
+)
+def test_all_one_app(all_func: Callable, expected: str, unexpected: str):
+    status_dict = copy.deepcopy(json.loads(SNAPPASS_JSON))
+    status_dict['applications']['snappass-test']['application-status']['current'] = expected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = expected
+    status = jubilant.Status._from_dict(status_dict)
+    assert all_func(status)
+    assert all_func(status, ['snappass-test'])
+    assert not all_func(status, ['other'])
+    assert not all_func(status, ['snappass-test', 'other'])
+
+    # Should return False if app status is not the expected status
+    status_dict['applications']['snappass-test']['application-status']['current'] = unexpected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = expected
+    status = jubilant.Status._from_dict(status_dict)
+    assert not all_func(status)
+
+    # Should return False if one of the unit's statuses is not the expected status
+    status_dict['applications']['snappass-test']['application-status']['current'] = expected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = unexpected
+    status = jubilant.Status._from_dict(status_dict)
+    assert not all_func(status)
+
+
+@pytest.mark.parametrize(
+    'any_func,expected,unexpected',
+    [
+        (jubilant.any_active, 'active', 'error'),
+        (jubilant.any_blocked, 'blocked', 'error'),
+        (jubilant.any_error, 'error', 'active'),
+        (jubilant.any_maintenance, 'maintenance', 'error'),
+        (jubilant.any_waiting, 'waiting', 'error'),
+    ],
+)
+def test_any_one_app(any_func: Callable, expected: str, unexpected: str):
+    status_dict = copy.deepcopy(json.loads(SNAPPASS_JSON))
+    status_dict['applications']['snappass-test']['application-status']['current'] = expected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = expected
+    status = jubilant.Status._from_dict(status_dict)
+    assert any_func(status)
+    assert any_func(status, ['snappass-test'])
+    assert not any_func(status, ['other'])
+    assert any_func(status, ['snappass-test', 'other'])
+
+    # Should return True if app status is not the expected status but unit status is
+    status_dict['applications']['snappass-test']['application-status']['current'] = unexpected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = expected
+    status = jubilant.Status._from_dict(status_dict)
+    assert any_func(status)
+
+    # Should return True if app status is expected but one of the unit's statuses is not
+    status_dict['applications']['snappass-test']['application-status']['current'] = expected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = unexpected
+    status = jubilant.Status._from_dict(status_dict)
+    assert any_func(status)
+
+
+@pytest.mark.parametrize(
+    'all_func,expected,unexpected',
+    [
+        (jubilant.all_active, 'active', 'error'),
+        (jubilant.all_blocked, 'blocked', 'error'),
+        (jubilant.all_error, 'error', 'active'),
+        (jubilant.all_maintenance, 'maintenance', 'error'),
+        (jubilant.all_waiting, 'waiting', 'error'),
+    ],
+)
+def test_all_two_apps(all_func: Callable, expected: str, unexpected: str):
+    status_dict = copy.deepcopy(json.loads(SNAPPASS_JSON))
+    status_dict['applications']['snappass-test']['application-status']['current'] = expected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = expected
+    # Add another app named "app2" unit one unit named "app2/0"
+    status_dict['applications']['app2'] = copy.deepcopy(
+        status_dict['applications']['snappass-test']
+    )
+    status_dict['applications']['app2']['units']['app2/0'] = status_dict['applications']['app2'][
+        'units'
+    ]['snappass-test/0']
+    del status_dict['applications']['app2']['units']['snappass-test/0']
+    status_dict['applications']['app2']['application-status']['current'] = expected
+    status_dict['applications']['app2']['units']['app2/0']['workload-status']['current'] = expected
+    status = jubilant.Status._from_dict(status_dict)
+    assert all_func(status)
+    assert all_func(status, ['snappass-test'])
+    assert all_func(status, ['snappass-test', 'app2'])
+    assert not all_func(status, ['snappass-test', 'other'])
+    assert not all_func(status, ['snappass-test', 'app2', 'other'])
+    assert not all_func(status, ['other1', 'other2'])
+
+    # Should return False if one app is the expected status but the other is not
+    status_dict['applications']['snappass-test']['application-status']['current'] = unexpected
+    status = jubilant.Status._from_dict(status_dict)
+    assert not all_func(status)
+
+    # Should return False if neither app has the expected status
+    status_dict['applications']['app2']['application-status']['current'] = unexpected
+    status = jubilant.Status._from_dict(status_dict)
+    assert not all_func(status)
+
+
+@pytest.mark.parametrize(
+    'any_func,expected,unexpected',
+    [
+        (jubilant.any_active, 'active', 'error'),
+        (jubilant.any_blocked, 'blocked', 'error'),
+        (jubilant.any_error, 'error', 'active'),
+        (jubilant.any_maintenance, 'maintenance', 'error'),
+        (jubilant.any_waiting, 'waiting', 'error'),
+    ],
+)
+def test_any_two_apps(any_func: Callable, expected: str, unexpected: str):
+    status_dict = copy.deepcopy(json.loads(SNAPPASS_JSON))
+    status_dict['applications']['snappass-test']['application-status']['current'] = expected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = expected
+    # Add another app named "app2" unit one unit named "app2/0"
+    status_dict['applications']['app2'] = copy.deepcopy(
+        status_dict['applications']['snappass-test']
+    )
+    status_dict['applications']['app2']['units']['app2/0'] = status_dict['applications']['app2'][
+        'units'
+    ]['snappass-test/0']
+    del status_dict['applications']['app2']['units']['snappass-test/0']
+    status_dict['applications']['app2']['application-status']['current'] = expected
+    status_dict['applications']['app2']['units']['app2/0']['workload-status']['current'] = expected
+    status = jubilant.Status._from_dict(status_dict)
+    assert any_func(status)
+    assert any_func(status, ['snappass-test'])
+    assert any_func(status, ['snappass-test', 'app2'])
+    assert any_func(status, ['snappass-test', 'other'])
+    assert any_func(status, ['snappass-test', 'app2', 'other'])
+    assert not any_func(status, ['other1', 'other2'])
+
+    # Should return True if one app is the expected status but the other is not
+    status_dict['applications']['snappass-test']['application-status']['current'] = unexpected
+    status_dict['applications']['snappass-test']['units']['snappass-test/0']['workload-status'][
+        'current'
+    ] = unexpected
+    status = jubilant.Status._from_dict(status_dict)
+    assert any_func(status)
+
+    # Should return False if neither app has the expected status
+    status_dict['applications']['app2']['application-status']['current'] = unexpected
+    status_dict['applications']['app2']['units']['app2/0']['workload-status']['current'] = (
+        unexpected
+    )
+    status = jubilant.Status._from_dict(status_dict)
+    assert not any_func(status)
+
+
+@pytest.mark.parametrize(
+    'all_func',
+    [
+        jubilant.all_active,
+        jubilant.all_blocked,
+        jubilant.all_error,
+        jubilant.all_maintenance,
+        jubilant.all_waiting,
+    ],
+)
+def test_all_type_errors(all_func: Callable):
+    with pytest.raises(TypeError):
+        all_func(None, 'app')
+    with pytest.raises(TypeError):
+        all_func(None, b'app')
+
+
+@pytest.mark.parametrize(
+    'any_func',
+    [
+        jubilant.any_active,
+        jubilant.any_blocked,
+        jubilant.any_error,
+        jubilant.any_maintenance,
+        jubilant.any_waiting,
+    ],
+)
+def test_any_type_errors(any_func: Callable):
+    with pytest.raises(TypeError):
+        any_func(None, 'app')
+    with pytest.raises(TypeError):
+        any_func(None, b'app')

--- a/test/unit/test_juju_class.py
+++ b/test/unit/test_juju_class.py
@@ -20,7 +20,7 @@ def test_init_args():
 def test_repr_defaults():
     juju = jubilant.Juju()
 
-    assert repr(juju) == "Juju(model=None, wait_timeout=180, cli_binary='juju')"
+    assert repr(juju) == "Juju(model=None, wait_timeout=180.0, cli_binary='juju')"
 
 
 def test_repr_args():

--- a/test/unit/test_juju_class.py
+++ b/test/unit/test_juju_class.py
@@ -1,0 +1,29 @@
+import jubilant
+
+
+def test_init_defaults():
+    juju = jubilant.Juju()
+
+    assert juju.model is None
+    assert juju.wait_timeout == 180
+    assert juju.cli_binary == 'juju'
+
+
+def test_init_args():
+    juju = jubilant.Juju(model='m', wait_timeout=7, cli_binary='/bin/juju3')
+
+    assert juju.model == 'm'
+    assert juju.wait_timeout == 7
+    assert juju.cli_binary == '/bin/juju3'
+
+
+def test_repr_defaults():
+    juju = jubilant.Juju()
+
+    assert repr(juju) == "Juju(model=None, wait_timeout=180, cli_binary='juju')"
+
+
+def test_repr_args():
+    juju = jubilant.Juju(model='m', wait_timeout=7, cli_binary='/bin/juju3')
+
+    assert repr(juju) == "Juju(model='m', wait_timeout=7, cli_binary='/bin/juju3')"

--- a/test/unit/test_status.py
+++ b/test/unit/test_status.py
@@ -2,35 +2,49 @@ import mocks
 
 import jubilant
 
+MINIMAL_JSON = """
+{
+    "model": {
+        "name": "mdl",
+        "type": "typ",
+        "controller": "ctl",
+        "cloud": "aws",
+        "version": "3.0.0"
+    },
+    "machines": {},
+    "applications": {}
+}
+"""
 
-def test_minimal(run: mocks.Run):
-    stdout = """{
-        "model": {
-            "name": "mdl",
-            "type": "typ",
-            "controller": "ctl",
-            "cloud": "aws",
-            "version": "3.0.0"
-        },
-        "machines": {},
-        "applications": {}
-    }"""
-    run.handle(['juju', 'status', '--format', 'json'], stdout=stdout)
+MINIMAL_STATUS = jubilant.Status(
+    model=jubilant.statustypes.ModelStatus(
+        name='mdl',
+        type='typ',
+        controller='ctl',
+        cloud='aws',
+        version='3.0.0',
+    ),
+    machines={},
+    apps={},
+)
+
+
+def test_minimal_no_model(run: mocks.Run):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
     juju = jubilant.Juju()
 
     status = juju.status()
 
-    assert status == jubilant.Status(
-        model=jubilant.statustypes.ModelStatus(
-            name='mdl',
-            type='typ',
-            controller='ctl',
-            cloud='aws',
-            version='3.0.0',
-        ),
-        machines={},
-        apps={},
-    )
+    assert status == MINIMAL_STATUS
+
+
+def test_minimal_with_model(run: mocks.Run):
+    run.handle(['juju', 'status', '--model', 'mdl', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju(model='mdl')
+
+    status = juju.status()
+
+    assert status == MINIMAL_STATUS
 
 
 def test_realistic():

--- a/test/unit/test_status.py
+++ b/test/unit/test_status.py
@@ -29,26 +29,7 @@ MINIMAL_STATUS = jubilant.Status(
 )
 
 
-def test_minimal_no_model(run: mocks.Run):
-    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
-    juju = jubilant.Juju()
-
-    status = juju.status()
-
-    assert status == MINIMAL_STATUS
-
-
-def test_minimal_with_model(run: mocks.Run):
-    run.handle(['juju', 'status', '--model', 'mdl', '--format', 'json'], stdout=MINIMAL_JSON)
-    juju = jubilant.Juju(model='mdl')
-
-    status = juju.status()
-
-    assert status == MINIMAL_STATUS
-
-
-def test_real_status(run: mocks.Run):
-    status_json = """
+SNAPPASS_JSON = """
 {
     "model": {
         "name": "tt",
@@ -109,7 +90,28 @@ def test_real_status(run: mocks.Run):
     }
 }
 """
-    run.handle(['juju', 'status', '--format', 'json'], stdout=status_json)
+
+
+def test_minimal_no_model(run: mocks.Run):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju()
+
+    status = juju.status()
+
+    assert status == MINIMAL_STATUS
+
+
+def test_minimal_with_model(run: mocks.Run):
+    run.handle(['juju', 'status', '--model', 'mdl', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju(model='mdl')
+
+    status = juju.status()
+
+    assert status == MINIMAL_STATUS
+
+
+def test_real_status(run: mocks.Run):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=SNAPPASS_JSON)
     juju = jubilant.Juju()
 
     status = juju.status()

--- a/test/unit/test_status.py
+++ b/test/unit/test_status.py
@@ -1,0 +1,38 @@
+import mocks
+
+import jubilant
+
+
+def test_minimal(run: mocks.Run):
+    stdout = """{
+        "model": {
+            "name": "mdl",
+            "type": "typ",
+            "controller": "ctl",
+            "cloud": "aws",
+            "version": "3.0.0"
+        },
+        "machines": {},
+        "applications": {}
+    }"""
+    run.handle(['juju', 'status', '--format', 'json'], stdout=stdout)
+    juju = jubilant.Juju()
+
+    status = juju.status()
+
+    assert status == jubilant.Status(
+        model=jubilant.statustypes.ModelStatus(
+            name='mdl',
+            type='typ',
+            controller='ctl',
+            cloud='aws',
+            version='3.0.0',
+        ),
+        machines={},
+        apps={},
+    )
+
+
+def test_realistic():
+    # TODO: get some JSON from a real Juju
+    pass

--- a/test/unit/test_status.py
+++ b/test/unit/test_status.py
@@ -47,6 +47,74 @@ def test_minimal_with_model(run: mocks.Run):
     assert status == MINIMAL_STATUS
 
 
-def test_realistic():
-    # TODO: get some JSON from a real Juju
-    pass
+def test_real_status(run: mocks.Run):
+    status_json = """
+{
+    "model": {
+        "name": "tt",
+        "type": "caas",
+        "controller": "microk8s-localhost",
+        "cloud": "microk8s",
+        "region": "localhost",
+        "version": "3.6.1",
+        "model-status": {
+            "current": "available",
+            "since": "24 Feb 2025 12:02:57+13:00"
+        },
+        "sla": "unsupported"
+    },
+    "machines": {},
+    "applications": {
+        "snappass-test": {
+            "charm": "snappass-test",
+            "base": {
+                "name": "ubuntu",
+                "channel": "20.04"
+            },
+            "charm-origin": "charmhub",
+            "charm-name": "snappass-test",
+            "charm-rev": 9,
+            "charm-channel": "latest/stable",
+            "scale": 1,
+            "provider-id": "276bec9f-6a0c-46ea-8094-aca6337d46e5",
+            "address": "10.152.183.248",
+            "exposed": false,
+            "application-status": {
+                "current": "active",
+                "message": "snappass started",
+                "since": "24 Feb 2025 12:03:17+13:00"
+            },
+            "units": {
+                "snappass-test/0": {
+                    "workload-status": {
+                        "current": "active",
+                        "message": "snappass started",
+                        "since": "24 Feb 2025 12:03:17+13:00"
+                    },
+                    "juju-status": {
+                        "current": "idle",
+                        "since": "24 Feb 2025 12:03:18+13:00",
+                        "version": "3.6.1"
+                    },
+                    "leader": true,
+                    "address": "10.1.164.138",
+                    "provider-id": "snappass-test-0"
+                }
+            }
+        }
+    },
+    "storage": {},
+    "controller": {
+        "timestamp": "12:04:55+13:00"
+    }
+}
+"""
+    run.handle(['juju', 'status', '--format', 'json'], stdout=status_json)
+    juju = jubilant.Juju()
+
+    status = juju.status()
+
+    assert status.model.type == 'caas'
+    assert status.apps['snappass-test'].is_active
+    assert status.apps['snappass-test'].units['snappass-test/0'].is_active
+    assert status.apps['snappass-test'].units['snappass-test/0'].leader

--- a/test/unit/test_statustypes.py
+++ b/test/unit/test_statustypes.py
@@ -1,0 +1,29 @@
+import json
+
+from test_status import MINIMAL_JSON, SNAPPASS_JSON
+
+import jubilant
+
+
+def test_status_str_minimal():
+    status = jubilant.Status._from_dict(json.loads(MINIMAL_JSON))
+    expected = [
+        'Model  Controller  Cloud/Region  Version  Timestamp  Notes',
+        'mdl    ctl         aws           3.0.0                    ',
+    ]
+    assert str(status).splitlines() == expected
+
+
+def test_status_str_snappass():
+    status = jubilant.Status._from_dict(json.loads(SNAPPASS_JSON))
+    expected = [
+        'Model  Controller          Cloud/Region        Version  Timestamp       Notes',
+        'tt     microk8s-localhost  microk8s/localhost  3.6.1    12:04:55+13:00       ',
+        '',
+        'App            Version  Status  Scale  Charm          Channel        Rev  Address         Exposed  Message         ',
+        'snappass-test           active  1      snappass-test  latest/stable  9    10.152.183.248  no       snappass started',
+        '',
+        'Unit              Workload  Agent  Machine  Address       Ports  Message',
+        'snappass-test/0*  active    idle            10.1.164.138                ',
+    ]
+    assert str(status).splitlines() == expected

--- a/test/unit/test_switch.py
+++ b/test/unit/test_switch.py
@@ -1,0 +1,12 @@
+import mocks
+
+import jubilant
+
+
+def test_basic(run: mocks.Run):
+    run.handle(['juju', 'switch', 'new'])
+    juju = jubilant.Juju(model='initial')
+
+    juju.switch('new')
+
+    assert juju.model == 'new'

--- a/test/unit/test_switch.py
+++ b/test/unit/test_switch.py
@@ -3,7 +3,16 @@ import mocks
 import jubilant
 
 
-def test_basic(run: mocks.Run):
+def test_no_model(run: mocks.Run):
+    run.handle(['juju', 'switch', 'new'])
+    juju = jubilant.Juju()
+
+    juju.switch('new')
+
+    assert juju.model == 'new'
+
+
+def test_with_model(run: mocks.Run):
     run.handle(['juju', 'switch', 'new'])
     juju = jubilant.Juju(model='initial')
 

--- a/test/unit/test_wait.py
+++ b/test/unit/test_wait.py
@@ -1,21 +1,48 @@
+import logging
+
 import mocks
+import pytest
 from test_status import MINIMAL_JSON, MINIMAL_STATUS
 
 import jubilant
 
 
-def test_wait_defaults(run: mocks.Run, time: mocks.Time):
+def test_ready_normal(run: mocks.Run, time: mocks.Time, caplog: pytest.LogCaptureFixture):
     run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
     juju = jubilant.Juju()
+    caplog.set_level(logging.INFO, logger='jubilant')
 
     status = juju.wait(lambda _: True)
 
     assert run.call_count == 3
     assert time.monotonic() == 2
     assert status == MINIMAL_STATUS
+    assert len(caplog.records) == 1  # only logs on first call or when status changes
+    assert 'status changed' in caplog.text
+    assert 'mdl' in caplog.text
 
 
-def test_wait_delay_successes(run: mocks.Run, time: mocks.Time):
+def test_ready_glitch(run: mocks.Run, time: mocks.Time):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju()
+
+    n = 0
+
+    def ready_glitch(_: jubilant.Status):
+        nonlocal n
+        n += 1
+        return n != 2  # Glitch on second call
+
+    status = juju.wait(ready_glitch)
+
+    # Should wait for three successful calls to ready in a row:
+    # ready, not ready, ready, ready, ready (5 total)
+    assert run.call_count == 5
+    assert time.monotonic() == 4
+    assert status == MINIMAL_STATUS
+
+
+def test_modified_delay_and_successes(run: mocks.Run, time: mocks.Time):
     run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
     juju = jubilant.Juju()
 
@@ -26,4 +53,40 @@ def test_wait_delay_successes(run: mocks.Run, time: mocks.Time):
     assert status == MINIMAL_STATUS
 
 
-# TODO: other wait tests
+def test_error(run: mocks.Run, time: mocks.Time):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju()
+
+    with pytest.raises(jubilant.WaitError) as excinfo:
+        juju.wait(lambda _: True, error=lambda _: True)
+
+    assert run.call_count == 1
+    assert time.monotonic() == 0
+    status_str = excinfo.value.__notes__[0]
+    assert 'mdl' in status_str
+
+
+def test_timeout_default(run: mocks.Run, time: mocks.Time):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju()
+
+    with pytest.raises(TimeoutError) as excinfo:
+        juju.wait(lambda _: False)
+
+    assert run.call_count == 180
+    assert time.monotonic() == 180
+    status_str = excinfo.value.__notes__[0]
+    assert 'mdl' in status_str
+
+
+def test_timeout_override(run: mocks.Run, time: mocks.Time):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju()
+
+    with pytest.raises(TimeoutError) as excinfo:
+        juju.wait(lambda _: False, timeout=5)
+
+    assert run.call_count == 5
+    assert time.monotonic() == 5
+    status_str = excinfo.value.__notes__[0]
+    assert 'mdl' in status_str

--- a/test/unit/test_wait.py
+++ b/test/unit/test_wait.py
@@ -1,0 +1,29 @@
+import mocks
+from test_status import MINIMAL_JSON, MINIMAL_STATUS
+
+import jubilant
+
+
+def test_wait_defaults(run: mocks.Run, time: mocks.Time):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju()
+
+    status = juju.wait(lambda _: True)
+
+    assert run.call_count == 3
+    assert time.monotonic() == 2
+    assert status == MINIMAL_STATUS
+
+
+def test_wait_delay_successes(run: mocks.Run, time: mocks.Time):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju()
+
+    status = juju.wait(lambda _: True, delay=0.5, successes=5)
+
+    assert run.call_count == 5
+    assert time.monotonic() == 2.0
+    assert status == MINIMAL_STATUS
+
+
+# TODO: other wait tests

--- a/uv.lock
+++ b/uv.lock
@@ -77,6 +77,45 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/d6/2b53ab3ee99f2262e6f0b8369a43f6d66658eab45510331c0b3d5c8c4272/coverage-7.6.12.tar.gz", hash = "sha256:48cfc4641d95d34766ad41d9573cc0f22a48aa88d22657a1fe01dca0dbae4de2", size = 805941 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/7f/4af2ed1d06ce6bee7eafc03b2ef748b14132b0bdae04388e451e4b2c529b/coverage-7.6.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b172f8e030e8ef247b3104902cc671e20df80163b60a203653150d2fc204d1ad", size = 208645 },
+    { url = "https://files.pythonhosted.org/packages/dc/60/d19df912989117caa95123524d26fc973f56dc14aecdec5ccd7d0084e131/coverage-7.6.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:641dfe0ab73deb7069fb972d4d9725bf11c239c309ce694dd50b1473c0f641c3", size = 208898 },
+    { url = "https://files.pythonhosted.org/packages/bd/10/fecabcf438ba676f706bf90186ccf6ff9f6158cc494286965c76e58742fa/coverage-7.6.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e549f54ac5f301e8e04c569dfdb907f7be71b06b88b5063ce9d6953d2d58574", size = 242987 },
+    { url = "https://files.pythonhosted.org/packages/4c/53/4e208440389e8ea936f5f2b0762dcd4cb03281a7722def8e2bf9dc9c3d68/coverage-7.6.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:959244a17184515f8c52dcb65fb662808767c0bd233c1d8a166e7cf74c9ea985", size = 239881 },
+    { url = "https://files.pythonhosted.org/packages/c4/47/2ba744af8d2f0caa1f17e7746147e34dfc5f811fb65fc153153722d58835/coverage-7.6.12-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bda1c5f347550c359f841d6614fb8ca42ae5cb0b74d39f8a1e204815ebe25750", size = 242142 },
+    { url = "https://files.pythonhosted.org/packages/e9/90/df726af8ee74d92ee7e3bf113bf101ea4315d71508952bd21abc3fae471e/coverage-7.6.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1ceeb90c3eda1f2d8c4c578c14167dbd8c674ecd7d38e45647543f19839dd6ea", size = 241437 },
+    { url = "https://files.pythonhosted.org/packages/f6/af/995263fd04ae5f9cf12521150295bf03b6ba940d0aea97953bb4a6db3e2b/coverage-7.6.12-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f16f44025c06792e0fb09571ae454bcc7a3ec75eeb3c36b025eccf501b1a4c3", size = 239724 },
+    { url = "https://files.pythonhosted.org/packages/1c/8e/5bb04f0318805e190984c6ce106b4c3968a9562a400180e549855d8211bd/coverage-7.6.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b076e625396e787448d27a411aefff867db2bffac8ed04e8f7056b07024eed5a", size = 241329 },
+    { url = "https://files.pythonhosted.org/packages/9e/9d/fa04d9e6c3f6459f4e0b231925277cfc33d72dfab7fa19c312c03e59da99/coverage-7.6.12-cp312-cp312-win32.whl", hash = "sha256:00b2086892cf06c7c2d74983c9595dc511acca00665480b3ddff749ec4fb2a95", size = 211289 },
+    { url = "https://files.pythonhosted.org/packages/53/40/53c7ffe3c0c3fff4d708bc99e65f3d78c129110d6629736faf2dbd60ad57/coverage-7.6.12-cp312-cp312-win_amd64.whl", hash = "sha256:7ae6eabf519bc7871ce117fb18bf14e0e343eeb96c377667e3e5dd12095e0288", size = 212079 },
+    { url = "https://files.pythonhosted.org/packages/76/89/1adf3e634753c0de3dad2f02aac1e73dba58bc5a3a914ac94a25b2ef418f/coverage-7.6.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:488c27b3db0ebee97a830e6b5a3ea930c4a6e2c07f27a5e67e1b3532e76b9ef1", size = 208673 },
+    { url = "https://files.pythonhosted.org/packages/ce/64/92a4e239d64d798535c5b45baac6b891c205a8a2e7c9cc8590ad386693dc/coverage-7.6.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5d1095bbee1851269f79fd8e0c9b5544e4c00c0c24965e66d8cba2eb5bb535fd", size = 208945 },
+    { url = "https://files.pythonhosted.org/packages/b4/d0/4596a3ef3bca20a94539c9b1e10fd250225d1dec57ea78b0867a1cf9742e/coverage-7.6.12-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0533adc29adf6a69c1baa88c3d7dbcaadcffa21afbed3ca7a225a440e4744bf9", size = 242484 },
+    { url = "https://files.pythonhosted.org/packages/1c/ef/6fd0d344695af6718a38d0861408af48a709327335486a7ad7e85936dc6e/coverage-7.6.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53c56358d470fa507a2b6e67a68fd002364d23c83741dbc4c2e0680d80ca227e", size = 239525 },
+    { url = "https://files.pythonhosted.org/packages/0c/4b/373be2be7dd42f2bcd6964059fd8fa307d265a29d2b9bcf1d044bcc156ed/coverage-7.6.12-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64cbb1a3027c79ca6310bf101014614f6e6e18c226474606cf725238cf5bc2d4", size = 241545 },
+    { url = "https://files.pythonhosted.org/packages/a6/7d/0e83cc2673a7790650851ee92f72a343827ecaaea07960587c8f442b5cd3/coverage-7.6.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79cac3390bfa9836bb795be377395f28410811c9066bc4eefd8015258a7578c6", size = 241179 },
+    { url = "https://files.pythonhosted.org/packages/ff/8c/566ea92ce2bb7627b0900124e24a99f9244b6c8c92d09ff9f7633eb7c3c8/coverage-7.6.12-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9b148068e881faa26d878ff63e79650e208e95cf1c22bd3f77c3ca7b1d9821a3", size = 239288 },
+    { url = "https://files.pythonhosted.org/packages/7d/e4/869a138e50b622f796782d642c15fb5f25a5870c6d0059a663667a201638/coverage-7.6.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8bec2ac5da793c2685ce5319ca9bcf4eee683b8a1679051f8e6ec04c4f2fd7dc", size = 241032 },
+    { url = "https://files.pythonhosted.org/packages/ae/28/a52ff5d62a9f9e9fe9c4f17759b98632edd3a3489fce70154c7d66054dd3/coverage-7.6.12-cp313-cp313-win32.whl", hash = "sha256:200e10beb6ddd7c3ded322a4186313d5ca9e63e33d8fab4faa67ef46d3460af3", size = 211315 },
+    { url = "https://files.pythonhosted.org/packages/bc/17/ab849b7429a639f9722fa5628364c28d675c7ff37ebc3268fe9840dda13c/coverage-7.6.12-cp313-cp313-win_amd64.whl", hash = "sha256:2b996819ced9f7dbb812c701485d58f261bef08f9b85304d41219b1496b591ef", size = 212099 },
+    { url = "https://files.pythonhosted.org/packages/d2/1c/b9965bf23e171d98505eb5eb4fb4d05c44efd256f2e0f19ad1ba8c3f54b0/coverage-7.6.12-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:299cf973a7abff87a30609879c10df0b3bfc33d021e1adabc29138a48888841e", size = 209511 },
+    { url = "https://files.pythonhosted.org/packages/57/b3/119c201d3b692d5e17784fee876a9a78e1b3051327de2709392962877ca8/coverage-7.6.12-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b467a8c56974bf06e543e69ad803c6865249d7a5ccf6980457ed2bc50312703", size = 209729 },
+    { url = "https://files.pythonhosted.org/packages/52/4e/a7feb5a56b266304bc59f872ea07b728e14d5a64f1ad3a2cc01a3259c965/coverage-7.6.12-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2458f275944db8129f95d91aee32c828a408481ecde3b30af31d552c2ce284a0", size = 253988 },
+    { url = "https://files.pythonhosted.org/packages/65/19/069fec4d6908d0dae98126aa7ad08ce5130a6decc8509da7740d36e8e8d2/coverage-7.6.12-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a9d8be07fb0832636a0f72b80d2a652fe665e80e720301fb22b191c3434d924", size = 249697 },
+    { url = "https://files.pythonhosted.org/packages/1c/da/5b19f09ba39df7c55f77820736bf17bbe2416bbf5216a3100ac019e15839/coverage-7.6.12-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14d47376a4f445e9743f6c83291e60adb1b127607a3618e3185bbc8091f0467b", size = 252033 },
+    { url = "https://files.pythonhosted.org/packages/1e/89/4c2750df7f80a7872267f7c5fe497c69d45f688f7b3afe1297e52e33f791/coverage-7.6.12-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b95574d06aa9d2bd6e5cc35a5bbe35696342c96760b69dc4287dbd5abd4ad51d", size = 251535 },
+    { url = "https://files.pythonhosted.org/packages/78/3b/6d3ae3c1cc05f1b0460c51e6f6dcf567598cbd7c6121e5ad06643974703c/coverage-7.6.12-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:ecea0c38c9079570163d663c0433a9af4094a60aafdca491c6a3d248c7432827", size = 249192 },
+    { url = "https://files.pythonhosted.org/packages/6e/8e/c14a79f535ce41af7d436bbad0d3d90c43d9e38ec409b4770c894031422e/coverage-7.6.12-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2251fabcfee0a55a8578a9d29cecfee5f2de02f11530e7d5c5a05859aa85aee9", size = 250627 },
+    { url = "https://files.pythonhosted.org/packages/cb/79/b7cee656cfb17a7f2c1b9c3cee03dd5d8000ca299ad4038ba64b61a9b044/coverage-7.6.12-cp313-cp313t-win32.whl", hash = "sha256:eb5507795caabd9b2ae3f1adc95f67b1104971c22c624bb354232d65c4fc90b3", size = 212033 },
+    { url = "https://files.pythonhosted.org/packages/b6/c3/f7aaa3813f1fa9a4228175a7bd368199659d392897e184435a3b66408dd3/coverage-7.6.12-cp313-cp313t-win_amd64.whl", hash = "sha256:f60a297c3987c6c02ffb29effc70eadcbb412fe76947d394a1091a3615948e2f", size = 213240 },
+    { url = "https://files.pythonhosted.org/packages/fb/b2/f655700e1024dec98b10ebaafd0cedbc25e40e4abe62a3c8e2ceef4f8f0a/coverage-7.6.12-py3-none-any.whl", hash = "sha256:eb8668cfbc279a536c633137deeb9435d2962caec279c3f8cf8b91fff6ff8953", size = 200552 },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -133,6 +172,7 @@ source = { virtual = "." }
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 docs = [
@@ -146,6 +186,7 @@ docs = [
 dev = [
     { name = "pyright", specifier = "==1.1.394" },
     { name = "pytest", specifier = "==8.3.4" },
+    { name = "pytest-cov", specifier = "==6.0.0" },
     { name = "ruff", specifier = "==0.9.6" },
 ]
 docs = [
@@ -253,6 +294,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
 ]
 
 [[package]]


### PR DESCRIPTION
NOTE: this branches off #34, so until that's merged the PR diff includes those changes too.

This adds a custom `Status.__str__`, as the default `dataclasses` one is massive and impossible to read for a structure this large. `str(status)` is logged by `Juju.wait` the first iteration or whenever the status changes after that, and it will be important for debugging CI to a clear, human-readable representation of the current status.

It seems best to model this after `juju status` output (the default, tabular output). It's a little simplified in some cases, but the structure is the same, for example:

```
Model  Controller          Cloud/Region        Version  Timestamp       Notes
tt     microk8s-localhost  microk8s/localhost  3.6.1    12:04:55+13:00

App            Version  Status  Scale  Charm          Channel        Rev  Address         Exposed  Message
snappass-test           active  1      snappass-test  latest/stable  9    10.152.183.248  no       snappass started

Unit              Workload  Agent  Machine  Address       Ports  Message
snappass-test/0*  active    idle            10.1.164.138
```

Fixes #24