### PR TITLE
feat: add "config" method and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ jubilant.egg-info
 /dist
 /SCRATCH.md
 /docs/_build
+/docs/.sphinx
 /.idea
 /t.py
 /.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dynamic = ["version"]
 
 [dependency-groups]
 dev = [
-    "pyright==1.1.394",
+    "pyright==1.1.395",
     "pytest==8.3.4",
     "pytest-cov==6.0.0",
     "ruff==0.9.6",

--- a/test/unit/mocks.py
+++ b/test/unit/mocks.py
@@ -16,7 +16,7 @@ class Run:
         self._commands = {}
         self.call_count = 0
 
-    def handle(self, args: list[str], returncode: int = 0, stdout: str = '', stderr: str = ''):
+    def handle(self, args: list[str], *, returncode: int = 0, stdout: str = '', stderr: str = ''):
         """Handle specified command-line args with the given return code, stdout, and stderr."""
         self._commands[tuple(args)] = (returncode, stdout, stderr)
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,0 +1,65 @@
+import jubilant
+
+from . import mocks
+
+CONFIG_JSON = """
+{
+    "settings": {
+        "booly": {"value": true},
+        "inty": {"value": 42},
+        "floaty": {"value": 7.5},
+        "stry": {"value": "A string."}
+    }
+}
+"""
+
+
+def test_get(run: mocks.Run):
+    run.handle(['juju', 'config', '--format', 'json', 'app1'], stdout=CONFIG_JSON)
+
+    juju = jubilant.Juju()
+    values = juju.config('app1')
+    assert values == {'booly': True, 'inty': 42, 'floaty': 7.5, 'stry': 'A string.'}
+
+
+def test_get_with_model(run: mocks.Run):
+    run.handle(
+        ['juju', 'config', '--model', 'mdl', '--format', 'json', 'app1'], stdout=CONFIG_JSON
+    )
+
+    juju = jubilant.Juju(model='mdl')
+    values = juju.config('app1')
+    assert values == {'booly': True, 'inty': 42, 'floaty': 7.5, 'stry': 'A string.'}
+
+
+def test_set(run: mocks.Run):
+    run.handle(['juju', 'config', 'app2', 'booly=true', 'inty=42', 'floaty=7.5', 'stry=A string.'])
+
+    juju = jubilant.Juju()
+    values = {'booly': True, 'inty': 42, 'floaty': 7.5, 'stry': 'A string.'}
+    retval = juju.config('app2', values)
+    assert retval is None
+
+
+def test_set_with_model(run: mocks.Run):
+    run.handle(['juju', 'config', 'app2', 'foo=bar'])
+
+    juju = jubilant.Juju()
+    retval = juju.config('app2', {'foo': 'bar'})
+    assert retval is None
+
+
+def test_reset(run: mocks.Run):
+    run.handle(['juju', 'config', 'app1', '--reset', 'x,why,zed'])
+
+    juju = jubilant.Juju()
+    retval = juju.config('app1', {'x': None, 'why': None, 'zed': None})
+    assert retval is None
+
+
+def test_set_with_reset(run: mocks.Run):
+    run.handle(['juju', 'config', 'app1', 'foo=bar', '--reset', 'baz,buzz'])
+
+    juju = jubilant.Juju()
+    retval = juju.config('app1', {'foo': 'bar', 'baz': None, 'buzz': None})
+    assert retval is None

--- a/test/unit/test_deploy.py
+++ b/test/unit/test_deploy.py
@@ -3,7 +3,7 @@ import jubilant
 from . import mocks
 
 
-def test_defaults_no_model(run: mocks.Run):
+def test_defaults(run: mocks.Run):
     run.handle(['juju', 'deploy', 'xyz'])
     juju = jubilant.Juju()
 

--- a/test/unit/test_status.py
+++ b/test/unit/test_status.py
@@ -4,7 +4,7 @@ from . import mocks
 from .fake_statuses import MINIMAL_JSON, MINIMAL_STATUS, SNAPPASS_JSON
 
 
-def test_minimal_no_model(run: mocks.Run):
+def test_minimal(run: mocks.Run):
     run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
     juju = jubilant.Juju()
 

--- a/test/unit/test_switch.py
+++ b/test/unit/test_switch.py
@@ -3,7 +3,7 @@ import jubilant
 from . import mocks
 
 
-def test_no_model(run: mocks.Run):
+def test(run: mocks.Run):
     run.handle(['juju', 'switch', 'new'])
     juju = jubilant.Juju()
 

--- a/test/unit/test_wait.py
+++ b/test/unit/test_wait.py
@@ -23,6 +23,17 @@ def test_ready_normal(run: mocks.Run, time: mocks.Time, caplog: pytest.LogCaptur
     assert 'mdl' in caplog.text
 
 
+def test_with_model(run: mocks.Run, time: mocks.Time):
+    run.handle(['juju', 'status', '--model', 'mdl', '--format', 'json'], stdout=MINIMAL_JSON)
+    juju = jubilant.Juju(model='mdl')
+
+    status = juju.wait(lambda _: True)
+
+    assert run.call_count == 3
+    assert time.monotonic() == 2
+    assert status == MINIMAL_STATUS
+
+
 def test_ready_glitch(run: mocks.Run, time: mocks.Time):
     run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
     juju = jubilant.Juju()

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ docs = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pyright", specifier = "==1.1.394" },
+    { name = "pyright", specifier = "==1.1.395" },
     { name = "pytest", specifier = "==8.3.4" },
     { name = "pytest-cov", specifier = "==6.0.0" },
     { name = "ruff", specifier = "==0.9.6" },
@@ -270,15 +270,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.394"
+version = "1.1.395"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/79f4d8a342eed6790fdebdb500e95062f319ee3d7d75ae27304ff995ae8c/pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608", size = 3809348 }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/47/a2e1dfd70f9f0db34f70d5b108c82be57bf24185af69c95acff57f9239fa/pyright-1.1.395.tar.gz", hash = "sha256:53703169068c160bfb41e1b44ba3e2512492869c26cfad927e1268cb3fbb1b1c", size = 3813566 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
+    { url = "https://files.pythonhosted.org/packages/5f/a1/531897f8caa6c6cc99862cd1c908ddd8a366a51d968e83ab4523ded98b30/pyright-1.1.395-py3-none-any.whl", hash = "sha256:f9bc726870e740c6c77c94657734d90563a3e9765bb523b39f5860198ed75eef", size = 5688787 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a `config` method for the `juju config` CLI command. After discussion, we've decide to use a single method for get and set as it's more 1:1 with the CLI command, and is pretty straight-forward to type (with `@overload`). 

Also:

- Change `dict[K, V]` arguments to `Mapping[K, V]`
- Bump Pyright to latest version
- In docstrings, use *arg* instead of "arg" for mentioning argument names, like the Python docs do
- Add test_wait.test_with_model to cover that case
- For consistency, remove `_no_model` from test name that don't use model (just `_with_model` for those that do)

Fixes #6