### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security policy
+
+## Supported versions
+
+Security updates will be released for all major versions that have had releases in the last year.
+
+## Reporting a vulnerability
+
+Please provide a description of the issue, the steps you took to
+create the issue, affected versions, and, if known, mitigations for
+the issue.
+
+The easiest way to report a security issue is through
+[GitHub's security advisory for the Charm Tech team's canonical/operator project](https://github.com/canonical/operator/security/advisories/new). See
+[Privately reporting a security
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions on reporting using GitHub's security advisory feature.
+
+Our team's GitHub admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then figure out a fix, get a CVE
+assigned, and coordinate the release of the fix.
+
+You may also send email to security@ubuntu.com. Email may optionally be
+encrypted to OpenPGP key
+[`4072 60F7 616E CE4D 9D12 4627 98E9 740D C345 39E0`](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x407260f7616ece4d9d12462798e9740dc34539e0)
+
+If you have a deadline for public disclosure, please let us know.
+Our vulnerability management team intends to respond within 3 working
+days of your report. This project aims to resolve all vulnerabilities
+within 90 days.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.


### PR DESCRIPTION
Copied almost verbatim from canonical/operator. Even links to that project's security advisory reporting to avoid having to set this fledgling project's one up.