### PR TITLE
feat: add run method

### DIFF
--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -1,6 +1,7 @@
 """Jubilant is a Pythonic wrapper around the Juju CLI for integration testing."""
 
 from . import statustypes
+from ._actions import ActionError, ActionResult
 from ._all_any import (
     all_active,
     all_blocked,
@@ -17,6 +18,8 @@ from ._juju import CLIError, Juju, WaitError
 from .statustypes import Status
 
 __all__ = [
+    'ActionError',
+    'ActionResult',
     'CLIError',
     'Juju',
     'Status',

--- a/jubilant/_actions.py
+++ b/jubilant/_actions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -11,8 +11,8 @@ class ActionResult:
     success: bool
     """Whether the action was successful."""
 
-    status: str
-    """Status of the action, for example "completed" or "failed"."""
+    status: Literal['aborted', 'cancelled', 'completed', 'error', 'failed']
+    """Status of the action (Juju operation). Typically "completed" or "failed"."""
 
     task_id: str
     """Task ID of the action, for use with "juju show-task"."""
@@ -33,6 +33,9 @@ class ActionResult:
     stderr: str = ''
     """Stderr printed by the action hook."""
 
+    message: str = ''
+    """Failure message, if the charm provided a message when it failed the action."""
+
     log: list[str] = dataclasses.field(default_factory=list)
     """List of messages logged by the action hook."""
 
@@ -50,6 +53,7 @@ class ActionResult:
             return_code=return_code,
             stdout=stdout,
             stderr=stderr,
+            message=d.get('message') or '',
             log=d.get('log') or [],
             task_id=d['id'],
         )

--- a/jubilant/_actions.py
+++ b/jubilant/_actions.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ActionResult:
+    """Holds the results of Juju running an action on a single unit."""
+
+    success: bool
+    """Whether the action was successful."""
+
+    status: str
+    """Status of the action, for example "completed" or "failed"."""
+
+    task_id: str
+    """Task ID of the action, for use with "juju show-task"."""
+
+    results: dict[str, Any] = dataclasses.field(default_factory=dict)
+    """Results of the action provided by the charm.
+
+    This excludes the special "return-code", "stdout", and "stderr" keys
+    inserted by Juju; those values are provided by separate attributes.
+    """
+
+    return_code: int = 0
+    """Return code from executing the charm action hook."""
+
+    stdout: str = ''
+    """Stdout printed by the action hook."""
+
+    stderr: str = ''
+    """Stderr printed by the action hook."""
+
+    log: list[str] = dataclasses.field(default_factory=list)
+    """List of messages logged by the action hook."""
+
+    @classmethod
+    def _from_dict(cls, d: dict[str, Any]) -> ActionResult:
+        status = d['status']
+        results: dict[str, Any] = d.get('results') or {}
+        return_code = results.pop('return-code', 0)
+        stdout = results.pop('stdout', '')
+        stderr = results.pop('stderr', '')
+        return cls(
+            success=status == 'completed',
+            status=status,
+            results=results,
+            return_code=return_code,
+            stdout=stdout,
+            stderr=stderr,
+            log=d.get('log') or [],
+            task_id=d['id'],
+        )
+
+
+class ActionError(Exception):
+    """Exception raised when an action run on a single unit fails."""
+
+    result: ActionResult
+    """Results of running the action."""
+
+    def __init__(self, result: ActionResult):
+        self.result = result

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -7,9 +7,7 @@ import time
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
-import yaml
-
-from . import ActionError
+from . import ActionError, _yaml
 from ._actions import ActionResult
 from .statustypes import Status
 
@@ -271,7 +269,7 @@ class Juju:
         params_file = None
         if params is not None:
             with tempfile.NamedTemporaryFile('w+', delete=False) as params_file:
-                yaml.safe_dump(params, params_file)
+                _yaml.safe_dump(params, params_file)
             args.extend(['--params', params_file.name])
 
         try:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -9,8 +9,8 @@ import time
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any, overload
 
-from . import ActionError, _yaml
-from ._actions import ActionResult
+from . import _yaml
+from ._actions import ActionError, ActionResult
 from .statustypes import Status
 
 logger = logging.getLogger('jubilant')

--- a/jubilant/_yaml.py
+++ b/jubilant/_yaml.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeVar, overload
+
+import yaml
+
+# These types were taken from typeshed:
+# https://github.com/python/typeshed/blob/e6165eadd680f45b00e37ba9342b5073bc884132/stubs/PyYAML/yaml/__init__.pyi
+_T_co = TypeVar('_T_co', covariant=True)
+
+
+class SupportsRead(Protocol[_T_co]):
+    def read(self, length: int = ..., /) -> _T_co: ...
+
+
+type _ReadStream = str | bytes | SupportsRead[str] | SupportsRead[bytes]
+
+_T_contra = TypeVar('_T_contra', str, bytes, contravariant=True)
+
+
+class _WriteStream(Protocol[_T_contra]):
+    def write(self, data: _T_contra, /) -> object: ...
+
+
+# Use C speedups if available.
+_safe_loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+_safe_dumper = getattr(yaml, 'CSafeDumper', yaml.SafeDumper)
+
+
+def safe_load(stream: _ReadStream) -> Any:
+    """Same as yaml.safe_load, but use fast C loader if available."""
+    return yaml.load(stream, Loader=_safe_loader)  # noqa: S506
+
+
+@overload
+def safe_dump(data: Any, stream: _WriteStream[Any]) -> None: ...
+
+
+@overload
+def safe_dump(data: Any, stream: None = None) -> str: ...
+
+
+def safe_dump(data: Any, stream: _WriteStream[Any] | None = None) -> str | None:
+    """Same as yaml.safe_dump, but use fast C dumper if available."""
+    return yaml.dump(data, stream=stream, Dumper=_safe_dumper)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ readme = "README.md"
 requires-python = ">=3.12"
 dynamic = ["version"]
 
+dependencies = [
+    "PyYAML==6.*",
+]
+
 [dependency-groups]
 dev = [
     "pyright==1.1.394",

--- a/test/unit/test_run.py
+++ b/test/unit/test_run.py
@@ -1,0 +1,190 @@
+import os.path
+import subprocess
+from typing import Any
+
+import pytest
+import yaml
+
+import jubilant
+
+from . import mocks
+
+
+def test_single_unit(run: mocks.Run):
+    out_json = """
+{
+  "mysql/0": {
+    "id": "42",
+    "log": [
+      "2025-03-01 16:23:26 +1300 NZDT Log message",
+      "2025-03-01 16:23:26 +1300 NZDT Another message"
+    ],
+    "results": {
+      "password": "pass",
+      "return-code": 0,
+      "username": "user",
+      "stdout": "OUT",
+      "stderr": "ERR"
+    },
+    "status": "completed"
+  }
+}
+"""
+    run.handle(['juju', 'run', '--format', 'json', 'mysql/0', 'get-password'], stdout=out_json)
+    juju = jubilant.Juju()
+
+    result = juju.run('mysql/0', 'get-password')
+
+    assert result == jubilant.ActionResult(
+        success=True,
+        status='completed',
+        task_id='42',
+        results={'username': 'user', 'password': 'pass'},
+        return_code=0,
+        stdout='OUT',
+        stderr='ERR',
+        log=[
+            '2025-03-01 16:23:26 +1300 NZDT Log message',
+            '2025-03-01 16:23:26 +1300 NZDT Another message',
+        ],
+    )
+
+
+def test_single_unit_not_found(run: mocks.Run):
+    run.handle(['juju', 'run', '--format', 'json', 'mysql/0', 'get-password'])
+    juju = jubilant.Juju()
+
+    with pytest.raises(ValueError):
+        juju.run('mysql/0', 'get-password')
+
+
+def test_single_unit_failed(run: mocks.Run):
+    out_json = """
+{
+  "mysql/0": {
+    "id": "42",
+    "results": {
+      "foo": "bar",
+      "return-code": 1,
+      "stderr": "Uncaught Exception in charm code: thing happened..."
+    },
+    "status": "failed"
+  }
+}
+"""
+    run.handle(['juju', 'run', '--format', 'json', 'mysql/0', 'faily'], stdout=out_json)
+    juju = jubilant.Juju()
+
+    with pytest.raises(jubilant.ActionError) as excinfo:
+        juju.run('mysql/0', 'faily')
+
+    assert excinfo.value.result == jubilant.ActionResult(
+        success=False,
+        status='failed',
+        task_id='42',
+        results={'foo': 'bar'},
+        return_code=1,
+        stderr='Uncaught Exception in charm code: thing happened...',
+    )
+
+
+def test_multiple_units(run: mocks.Run):
+    out_json = """
+{
+  "mysql/0": {
+    "id": "43",
+    "results": {
+      "password": "pass0",
+      "return-code": 0,
+      "username": "user0"
+    },
+    "status": "completed"
+  },
+  "mysql/1": {
+    "id": "44",
+    "results": {
+      "password": "pass1",
+      "return-code": 0,
+      "username": "user1"
+    },
+    "status": "failed"
+  }
+}
+"""
+    run.handle(
+        ['juju', 'run', '--format', 'json', 'mysql/0', 'mysql/1', 'mysql/2', 'get-password'],
+        stdout=out_json,
+    )
+    juju = jubilant.Juju()
+
+    results = juju.run(['mysql/0', 'mysql/1', 'mysql/2'], 'get-password')
+
+    assert results == {
+        'mysql/0': jubilant.ActionResult(
+            success=True,
+            status='completed',
+            task_id='43',
+            results={'username': 'user0', 'password': 'pass0'},
+        ),
+        'mysql/1': jubilant.ActionResult(
+            success=False,
+            status='failed',
+            task_id='44',
+            results={'username': 'user1', 'password': 'pass1'},
+        ),
+    }
+
+    # Ensure type checker thinks it looks like a dict
+    assert len(results) == 2
+    assert results['mysql/0']
+
+    # Ensure that passing a tuple of unit names also works
+    results_tuple = juju.run(('mysql/0', 'mysql/1', 'mysql/2'), 'get-password')
+    assert results_tuple == results
+
+
+def test_params(monkeypatch: pytest.MonkeyPatch):
+    stdout = """
+{
+  "mysql/0": {
+    "id": "42",
+    "results": {
+      "password": "pass",
+      "return-code": 0,
+      "username": "user"
+    },
+    "status": "completed"
+  }
+}"""
+    params_path = ''
+
+    def mock_run(args: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal params_path
+        assert args[:-1] == [
+            'juju',
+            'run',
+            '--format',
+            'json',
+            'mysql/0',
+            'get-password',
+            '--params',
+        ]
+        (params_path,) = args[-1:]  # Ensure there's no extra args
+        with open(params_path) as f:
+            params = yaml.safe_load(f)
+        assert params == {'foo': 1, 'bar': ['ab', 'cd']}
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout)
+
+    monkeypatch.setattr('subprocess.run', mock_run)
+    juju = jubilant.Juju()
+
+    result = juju.run('mysql/0', 'get-password', {'foo': 1, 'bar': ['ab', 'cd']})
+
+    assert result == jubilant.ActionResult(
+        success=True,
+        status='completed',
+        task_id='42',
+        results={'username': 'user', 'password': 'pass'},
+    )
+    assert params_path
+    assert not os.path.exists(params_path)

--- a/uv.lock
+++ b/uv.lock
@@ -167,6 +167,9 @@ wheels = [
 name = "jubilant"
 version = "0.0.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -181,6 +184,7 @@ docs = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = "==6.*" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -307,6 +311,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds support for the "juju run" command. Don't support `--background` mode or `juju show-operation` for now (likely not needed for integration testing).

This PR adds a dependency on PyYAML, which is kind of inevitable at some point. All params are passed as YAML, to ensure they round trip with the correct types (and to avoid ad-hoc foo.bar=baz serialization on the command line).

I played around with the API design / signature of this for a while. Initially I had an `@overload` that supported the `unit` parameter being either a single unit name a list/tuple of unit names, but the return value was too complex (`ActionResult` in single case, `dict[str, ActionResult]` in the other). We decided to stick with the single-unit version for now, and we can add `run_multiple` or something later.

Fixes #13