### PR TITLE
chore: ignore spelling of params (in *param*) and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ jubilant.egg-info
 /dist
 /SCRATCH.md
 /docs/_build
-/docs/.sphinx
 /.idea
 /t.py
 /.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ __pycache__
 jubilant.egg-info
 /dist
 /SCRATCH.md
-/docs/_build
 /.idea
 /t.py
 /.coverage

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -30,5 +30,6 @@ matrix:
             - a.contributor
             - span.pre
             - .sig-object
+            - '#module-jubilant em'
             - '#module-jubilant strong'
             - '#module-jubilant a.reference'


### PR DESCRIPTION
Combining two small adjustments:

- Updated the spelling exceptions in `spellingcheck.yaml` to exclude `*emphasised*` text, which is conventionally used when mentioning parameter names. I previously excluded `**bold**` text for a similar reason - the auto generated lists of params wrap the param names in `<strong>` tags (without any other class to identify these elements). I think this approach is fine, as we're unlikely to use emphasised or bold text outside of these contexts in the reference docs.

- Removed `/docs/.sphinx` from the top-level .gitignore file. We can't ignore the whole of the `.sphinx` dir as it has some important files, including `spellingcheck.yaml`. There's a doc-specific .gitignore file inside the `docs` dir.

- Removed `/docs/_build` from the top-level .gitignore file, as it's already specified in the doc-specific .gitignore.