### PR TITLE
chore: doc config changes for canonical-sphinx 0.4.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,7 @@ html_context = {
     'github_issues': 'enabled',
 }
 
-# To enable the edit button (a pencil icon next to the feedback button)
+# To enable the edit button (pencil icon next to the feedback button)
 #
 # html_theme_options = {
 # 'source_edit_link': 'https://github.com/canonical/jubilant',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,20 +140,20 @@ html_context = {
     # Docs branch in the repo; used in links for viewing the source files
     #
     # TODO: To customise the branch, uncomment and update as needed.
-    'github_version': 'main',
+    'repo_default_branch': 'main',
     # Docs location in the repo; used in links for viewing the source files
     #
 
 
     # TODO: To customise the directory, uncomment and update as needed.
-    "github_folder": "/docs/",
+    "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
     # "sequential_nav": "both",
     # TODO: To enable listing contributors on individual pages, set to True
     "display_contributors": False,
 
-    # Required for feedback button    
+    # Required for feedback button
     'github_issues': 'enabled',
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,6 +157,12 @@ html_context = {
     'github_issues': 'enabled',
 }
 
+# To enable the edit button (a pencil icon next to the feedback button)
+#
+# html_theme_options = {
+# 'source_edit_link': 'https://github.com/canonical/jubilant',
+# }
+
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,


### PR DESCRIPTION
[Version 0.4.0](https://github.com/canonical/canonical-sphinx/releases/tag/0.4.0) of `canonical-sphinx` requires changes in `docs/conf.py` to prevent build warnings:

- Renamed `github_folder` to `repo_folder`
- Renamed `github_version` to `repo_default_branch`

This version of `canonical-sphinx` also makes some changes to the page footers. The following links are gone:

- Discourse and Matrix - We expect people to use "More resources" in the top banner.
- Open a GitHub issue for this page - We expect people to use the "Give feedback" button under the top banner.
- Edit this page on GitHub - Replaced by an optional edit button next to the "Give feedback" button. I've left this disabled for now, but we can enable it in `docs/conf.py` if we like (see 2546c48).