### PR TITLE
docs: set maximum_signature_line_length to 80

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -348,3 +348,6 @@ autodoc_default_options = {
     'undoc-members': None,
     'show-inheritance': None,
 }
+
+# This value stacks args vertically if a signature is too long.
+maximum_signature_line_length = 80


### PR DESCRIPTION
Unfortunately this doesn't seem to work for dataclasses. I've played with a few things, like using python_maximum_signature_line_length instead, but it doesn't help. Oh well, this is good enough for now.