### PR TITLE
chore: spelling adjustments

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,5 +1,4 @@
 # Ensure the last line in this file has a newline at the end, to support concatenation
-AppStatus
 args
 CIDR
 CLI
@@ -18,6 +17,5 @@ statustypes
 stdout
 stderr
 teardown
-UnitStatus
 URI
 websocket

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -6,7 +6,6 @@ CLI
 cli
 config
 Dataclasses
-favorite
 Jubilant
 Jubilant's
 libjuju

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -9,8 +9,8 @@ Dataclasses
 Jubilant
 Jubilant's
 libjuju
-Microk
-Microk8s
+MicroK
+MicroK8s
 PyPI
 pytest
 Pythonic

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -2,7 +2,7 @@ matrix:
   - name: rST files
     aspell:
       lang: en
-      d: en_GB
+      d: en_US
     dictionary:
       wordlists:
         - .sphinx/.wordlist.txt

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -32,4 +32,6 @@ matrix:
             - .sig-object
             - '#module-jubilant em'
             - '#module-jubilant strong'
+            - '#module-jubilant.statustypes em'
+            - '#module-jubilant.statustypes strong'
             - a.reference[title^="jubilant."]

--- a/docs/.sphinx/spellingcheck.yaml
+++ b/docs/.sphinx/spellingcheck.yaml
@@ -32,4 +32,4 @@ matrix:
             - .sig-object
             - '#module-jubilant em'
             - '#module-jubilant strong'
-            - '#module-jubilant a.reference'
+            - a.reference[title^="jubilant."]

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -147,7 +147,7 @@ By default, `Juju.cli` adds a `--model=<model>` parameter if the `Juju` instance
 
 ## Use `concierge` in CI
 
-We recommend using [concierge](https://github.com/jnsgruk/concierge/) to set up Juju when running your integration tests in CI. It will install Juju with a provider like Microk8s and bootstrap a controller for you. For example, using GitHub Actions:
+We recommend using [concierge](https://github.com/jnsgruk/concierge/) to set up Juju when running your integration tests in CI. It will install Juju with a provider like MicroK8s and bootstrap a controller for you. For example, using GitHub Actions:
 
 ```
 - name: Install concierge


### PR DESCRIPTION
This PR adjusts a few spelling-related things:

- Since we've switched to US English, I changed the dictionary language (in `docs/.sphinx/spellingcheck.yaml`) and removed "favorite" from the list of custom exceptions.

- For MicroK8s, used the official spelling (with a capital K).

- Broadened the rules in `docs/.sphinx/spellingcheck.yaml` so that links to `jubilant.foo` reference docs are always ignored. The text of such links was ignored anyway (because the text uses code formatting), but some link titles were being flagged as spelling errors. That's why we needed to have `AppStatus` and `UnitStatus` in the list of custom exceptions.