### PR TITLE
docs: make example fixtures module-scoped, explain Python 3.12 requirement

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,6 @@ jobs:
     name: Checks
     runs-on: ubuntu-22.04
     outputs:
-      spellcheck-result: ${{ steps.spellcheck-step.outcome }}
       linkcheck-result: ${{ steps.linkcheck-step.outcome }}
     steps:
       - name: Checkout
@@ -29,12 +28,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Spelling
-        id: spellcheck-step
-        if: success() || failure()
-        uses: canonical/documentation-workflows/spellcheck@main
-        with:
-          working-directory: docs
       - name: Links
         id: linkcheck-step
         if: success() || failure()

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Jubilant is a Python library that wraps the [Juju](https://juju.is/) CLI for use
 
 You should consider switching to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) (and they probably do). Jubilant has an API you'll pick up quickly, and it avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`. Read our [design goals](https://canonical-jubilant.readthedocs-hosted.com/explanation/design-goals).
 
+Jubilant requires Python 3.12 or above. If your charm uses an Ubuntu base with an older Python version, run your integration tests with Python 3.12+ and install Jubilant with the requirement `jubilant;python_version>='3.12'` ([see an example](https://github.com/jnsgruk/zinc-k8s-operator/pull/355/files)).
+
 Jubilant is currently in pre-release or "beta" phase (see [PyPI releases](https://pypi.org/project/jubilant/#history)). Our intention is to release version 1.0.0 in May 2025.
 
 [**Read the full documentation**](https://canonical-jubilant.readthedocs-hosted.com/)

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ juju.deploy('snappass-test')
 juju.wait(jubilant.all_active)
 ```
 
-Below is an example of a charm integration test. First we define a [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) named `juju` which creates a temporary model and runs the test with a `Juju` instance pointing at that model. Jubilant's`temp_model` context manager creates the model during test setup and destroys it during teardown:
+Below is an example of a charm integration test. First we define a module-scoped [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) named `juju` which creates a temporary model and runs the test with a `Juju` instance pointing at that model. Jubilant's`temp_model` context manager creates the model during test setup and destroys it during teardown:
 
 ```python
 # conftest.py
-@pytest.fixture
+@pytest.fixture(scope='module')
 def juju():
     with jubilant.temp_model() as juju:
         yield juju

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -62,7 +62,7 @@ Model "test" is empty.
 
 We recommend using [pytest](https://docs.pytest.org/en/stable/) for writing tests. You can define a [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) to create a temporary Juju model for each test. The [](jubilant.temp_model) context manager creates a randomly-named model on entry, and destroys the model on exit.
 
-Here is a module-scope fixture called `juju`, which you would normally define in [`conftest.py`](https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files):
+Here is a module-scoped fixture called `juju`, which you would normally define in [`conftest.py`](https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files):
 
 ```python
 @pytest.fixture(scope='module')

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -60,16 +60,16 @@ Model "test" is empty.
 
 We recommend using [pytest](https://docs.pytest.org/en/stable/) for writing tests. You can define a [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) to create a temporary Juju model for each test. The [](jubilant.temp_model) context manager creates a randomly-named model on entry, and destroys the model on exit.
 
-Here is a model-setup fixture called `juju`, which you would normally define in [`conftest.py`](https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files):
+Here is a module-scope fixture called `juju`, which you would normally define in [`conftest.py`](https://docs.pytest.org/en/stable/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files):
 
 ```python
-@pytest.fixture
+@pytest.fixture(scope='module')
 def juju():
     with jubilant.temp_model() as juju:
         yield juju
 ```
 
-An integration test would use the fixture, operating on the temporary model:
+Integration tests in a test file would use the fixture, operating on the temporary model:
 
 ```python
 def test_deploy(juju: jubilant.Juju):
@@ -78,10 +78,10 @@ def test_deploy(juju: jubilant.Juju):
     assert status.apps['snappass-test'].scale == 1
 ```
 
-You may want to make your fixture [module-scoped](https://docs.pytest.org/en/stable/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session), to allow all the tests in one file to share the same temporary model:
+You may want to adjust the [scope](https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes) of your `juju` fixture. For example, if you want to create a new model for every test function, use `scope='function'`, or just omit the scope (function scope is pytest's default):
 
 ```python
-@pytest.fixture(scope='module')
+@pytest.fixture
 def juju():
     ...
 ```

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -80,7 +80,7 @@ def test_deploy(juju: jubilant.Juju):
     assert status.apps['snappass-test'].scale == 1
 ```
 
-You may want to adjust the [scope](https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes) of your `juju` fixture. For example, if you want to create a new model for every test function, use `scope='function'`, or just omit the scope (function scope is pytest's default):
+You may want to adjust the [scope](https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes) of your `juju` fixture. For example, to create a new model for every test function (pytest's default behavior), omit the scope:
 
 ```python
 @pytest.fixture

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -15,6 +15,8 @@ $ pip install jubilant
 $ uv add jubilant
 ```
 
+Jubilant requires Python 3.12 or above. If your charm uses an Ubuntu base with an older Python version, run your integration tests with Python 3.12+ and install Jubilant with the requirement `jubilant;python_version>='3.12'` ([see an example](https://github.com/jnsgruk/zinc-k8s-operator/pull/355/files)).
+
 
 ## Check your setup
 


### PR DESCRIPTION
This tweaks the docs in two ways (per feedback from @jnsgruk):

* Make the example fixtures in the README and docs *module*-scoped, to match what people are used to with pytest-operator (its fixtures are module-scoped).
* Prominently note the Python 3.12 requirement, as well as how to manage it if your charms are using on older version of Python (older Ubuntu base). I realise this is duplicated, but I think it's important enough to do in both README and docs tutorial.