### PR TITLE
test: add integration test of run (action) fail and exception

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -457,7 +457,14 @@ class Juju:
             args.extend(['--params', params_file.name])
 
         try:
-            stdout = self.cli(*args)
+            try:
+                stdout = self.cli(*args)
+            except CLIError as exc:
+                # The "juju run" CLI command fails if the action has an uncaught exception.
+                if 'task failed' not in exc.stderr:
+                    raise
+                stdout = exc.stdout
+
             # Command doesn't return any stdout if no units exist.
             all_results: dict[str, Any] = json.loads(stdout) if stdout.strip() else {}
             if unit not in all_results:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -443,7 +443,7 @@ class Juju:
             The result of the action, including logs, failure message, and so on.
 
         Raises:
-            ValueError: if the unit doesn't exist.
+            ValueError: if the action or the unit doesn't exist.
             ActionError: if the action failed.
         """
         args = ['run', '--format', 'json', unit, action]
@@ -468,7 +468,7 @@ class Juju:
             # Command doesn't return any stdout if no units exist.
             all_results: dict[str, Any] = json.loads(stdout) if stdout.strip() else {}
             if unit not in all_results:
-                raise ValueError(f'unit not found: {unit}')
+                raise ValueError(f'action {action!r} not defined, or unit {unit!r} not found')
             result = ActionResult._from_dict(all_results[unit])
             if not result.success:
                 raise ActionError(result)

--- a/tests/integration/charms/testdb/src/charm.py
+++ b/tests/integration/charms/testdb/src/charm.py
@@ -11,6 +11,11 @@ class Charm(ops.CharmBase):
         self.framework.observe(self.on['do_thing'].action, self._do_thing)
 
     def _do_thing(self, event: ops.ActionEvent):
+        if 'error' in event.params:
+            event.fail(f'failed with error: {event.params["error"]}')
+            return
+        if 'exception' in event.params:
+            raise Exception(event.params['exception'])
         event.set_results({'thingy': 'foo', 'params': event.params, 'config': dict(self.config)})
 
     def _on_db_relation_created(self, event: ops.RelationCreatedEvent):

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -59,6 +59,18 @@ def test_config_and_run(juju: jubilant.Juju):
         'thingy': 'foo',
     }
 
+    result = juju.run(charm + '/0', 'do-thing', {'error': 'ERR'})
+    assert not result.success
+    assert result.status == 'failed'
+    assert result.return_code == 0  # return_code is 0 even if action fails
+    assert result.message == 'failed with error: ERR'
+
+    result = juju.run(charm + '/0', 'do-thing', {'exception': 'EXC'})
+    assert not result.success
+    assert result.status == 'failed'
+    assert result.return_code != 0
+    assert 'EXC' in result.stderr
+
 
 def test_integrate(juju: jubilant.Juju):
     juju.deploy(charm_path('testdb'))

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -1,5 +1,6 @@
 import pathlib
 
+import pytest
 import requests
 
 import jubilant
@@ -59,13 +60,17 @@ def test_config_and_run(juju: jubilant.Juju):
         'thingy': 'foo',
     }
 
-    result = juju.run(charm + '/0', 'do-thing', {'error': 'ERR'})
+    with pytest.raises(jubilant.ActionError) as excinfo:
+        juju.run(charm + '/0', 'do-thing', {'error': 'ERR'})
+    result = excinfo.value.result
     assert not result.success
     assert result.status == 'failed'
     assert result.return_code == 0  # return_code is 0 even if action fails
     assert result.message == 'failed with error: ERR'
 
-    result = juju.run(charm + '/0', 'do-thing', {'exception': 'EXC'})
+    with pytest.raises(jubilant.ActionError) as excinfo:
+        juju.run(charm + '/0', 'do-thing', {'exception': 'EXC'})
+    result = excinfo.value.result
     assert not result.success
     assert result.status == 'failed'
     assert result.return_code != 0

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -58,7 +58,7 @@ def test_not_found(run: mocks.Run):
         juju.run('mysql/0', 'get-password')
 
 
-def test_failed(run: mocks.Run):
+def test_failure(run: mocks.Run):
     out_json = """
 {
   "mysql/0": {
@@ -66,8 +66,7 @@ def test_failed(run: mocks.Run):
     "message": "Failure message",
     "results": {
       "foo": "bar",
-      "return-code": 1,
-      "stderr": "Uncaught Exception in charm code: thing happened..."
+      "return-code": 0
     },
     "status": "failed"
   }
@@ -84,10 +83,61 @@ def test_failed(run: mocks.Run):
         status='failed',
         task_id='42',
         results={'foo': 'bar'},
-        return_code=1,
-        stderr='Uncaught Exception in charm code: thing happened...',
+        return_code=0,
         message='Failure message',
     )
+
+
+def test_exception_task_failed(run: mocks.Run):
+    out_json = """
+{
+  "mysql/0": {
+    "id": "42",
+    "results": {
+      "foo": "bar",
+      "return-code": 1,
+      "stderr": "Uncaught Exception in charm code: thing happened..."
+    },
+    "status": "failed"
+  }
+}
+"""
+    run.handle(
+        ['juju', 'run', '--format', 'json', 'mysql/0', 'exceptiony'],
+        returncode=1,
+        stdout=out_json,
+        stderr='... task failed ...',
+    )
+    juju = jubilant.Juju()
+
+    with pytest.raises(jubilant.ActionError) as excinfo:
+        juju.run('mysql/0', 'exceptiony')
+
+    assert excinfo.value.result == jubilant.ActionResult(
+        success=False,
+        status='failed',
+        task_id='42',
+        results={'foo': 'bar'},
+        return_code=1,
+        stderr='Uncaught Exception in charm code: thing happened...',
+    )
+
+
+def test_exception_other(run: mocks.Run):
+    run.handle(
+        ['juju', 'run', '--format', 'json', 'mysql/0', 'exceptiony'],
+        returncode=2,
+        stdout='OUT',
+        stderr='ERR',
+    )
+    juju = jubilant.Juju()
+
+    with pytest.raises(jubilant.CLIError) as excinfo:
+        juju.run('mysql/0', 'exceptiony')
+
+    assert excinfo.value.returncode == 2
+    assert excinfo.value.stdout == 'OUT'
+    assert excinfo.value.stderr == 'ERR'
 
 
 @pytest.mark.parametrize('cli_binary', ['/snap/bin/juju', '/bin/juju'])

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -80,7 +80,7 @@ def test_failure(run: mocks.Run):
 
     assert excinfo.value.result == jubilant.ActionResult(
         success=False,
-        status='failed',
+        status='failed',  # This is what causes the failure (even when return_code is 0)
         task_id='42',
         results={'foo': 'bar'},
         return_code=0,
@@ -128,7 +128,7 @@ def test_exception_other(run: mocks.Run):
         ['juju', 'run', '--format', 'json', 'mysql/0', 'exceptiony'],
         returncode=2,
         stdout='OUT',
-        stderr='ERR',
+        stderr='ERR',  # Must not contain "task failed"
     )
     juju = jubilant.Juju()
 


### PR DESCRIPTION
After [testing `juju exec`](https://github.com/canonical/jubilant/pull/66), I wanted to test errors and exceptions with `juju run`. It also needed a try/except to handle the "Uncaught exception in charm code" case, which returns a non-zero exit code and hence raises `CLIError`.