### PR TITLE
docs: add 'charmcraft pack' in sample GitHub action

### DIFF
--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -163,7 +163,9 @@ We recommend using [concierge](https://github.com/jnsgruk/concierge/) to set up 
           --preset microk8s
 
 - name: Run integration tests
-  run: uv run pytest tests/integration -vv --log-level=INFO
+  run: |
+      charmcraft pack
+      uv run pytest tests/integration -vv --log-level=INFO
 ```
 
 


### PR DESCRIPTION
This PR adds `charmcraft pack` to the sample GitHub action in [Use concierge in CI](https://canonical-jubilant.readthedocs-hosted.com/tutorial/getting-started/#use-concierge-in-ci), as discussed in #68.