### PR TITLE
fix: wait_timeout 3m -> 10m to match python-libjuju wait_for_idle's

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -77,7 +77,7 @@ class Juju:
         self,
         *,
         model: str | None = None,
-        wait_timeout: float = 3 * 60.0,
+        wait_timeout: float = 10 * 60.0,
         cli_binary: str | os.PathLike[str] | None = None,
     ):
         self.model = model

--- a/tests/unit/test_wait.py
+++ b/tests/unit/test_wait.py
@@ -95,8 +95,8 @@ def test_timeout_default(run: mocks.Run, time: mocks.Time):
     with pytest.raises(TimeoutError) as excinfo:
         juju.wait(lambda _: False)
 
-    assert len(run.calls) == 180
-    assert time.monotonic() == 180
+    assert len(run.calls) == 600
+    assert time.monotonic() == 600
     status_str = excinfo.value.__notes__[0]
     assert 'mdl' in status_str
 


### PR DESCRIPTION
Changing the default timeout to match python-libjuju's `wait_for_idle` default, just to make porting to Jubilant easier.