### PR TITLE
docs: change Juju links to point to latest doc site

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ pip install jubilant
 $ uv add jubilant
 ```
 
-Because Jubilant calls the Juju CLI, you'll also need to [install Juju](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-juju/#install-juju).
+Because Jubilant calls the Juju CLI, you'll also need to [install Juju](https://documentation.ubuntu.com/juju/latest/howto/manage-juju/index.html#install-juju).
 
 To use Jubilant in Python code:
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -2,7 +2,7 @@
 
 In this tutorial, we'll learn how to install Jubilant, use it to run Juju commands, and write a simple charm integration test.
 
-The tutorial assumes that you have a basic understanding of Juju and have already installed it. [Learn how to install the Juju CLI.](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-juju/#install-juju)
+The tutorial assumes that you have a basic understanding of Juju and have already installed it. [Learn how to install the Juju CLI.](https://documentation.ubuntu.com/juju/latest/howto/manage-juju/index.html#install-juju)
 
 
 ## Install Jubilant


### PR DESCRIPTION
Juju docs recently moved to documentation.ubuntu.com. This PR updates the two links we have. I considered setting up intersphinx, but it doesn't seem worth it right now.