### PR TITLE
feat: add "wait" argument to exec and run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,44 @@
 
-.PHONY: help
+# We're using Make as a command runner, so always make (avoids need for .PHONY)
+MAKEFLAGS += "--always-make"
+
 help:  # Display help
 	@echo "Usage: make [target] [ARGS='additional args']\n\nTargets:"
 	@awk -F'#' '/^[a-z-]+:/ { sub(":.*", "", $$1); print " ", $$1, "#", $$2 }' Makefile | column -t -s '#'
 
-.PHONY: all
 all: format lint static unit  # Run all quick, local commands
 
-.PHONE: coverage-html
 coverage-html:  # Write and open HTML coverage report from last unit test run
 	uv run coverage html
 	open htmlcov/index.html 2>/dev/null
 
-.PHONY: docs
 docs:  # Build documentation
 	$(MAKE) -C docs run
 
-.PHONY: fix
 fix:  # Fix linting issues
 	uv run ruff check --fix
 
-.PHONY: format
 format:  # Format the Python code
 	uv run ruff format
 
-.PHONY: integration
 integration:  # Run integration tests on Juju, eg: make integration ARGS='-k test_deploy'
 	uv run pytest tests/integration -vv --log-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" $(ARGS)
 
-.PHONY: lint
 lint:  # Perform linting
 	uv run ruff check
 	uv run ruff format --diff
 
-.PHONY: pack
 pack:  # Pack charms used by integration tests (requires charmcraft)
 	cd tests/integration/charms/testdb && charmcraft pack
 	cd tests/integration/charms/testapp && charmcraft pack
 
-.PHONY:
 publish-test:  # Publish to TestPyPI
 	rm -rf dist
 	uv build
 	uv publish --publish-url=https://test.pypi.org/legacy/ --token=$(UV_PUBLISH_TOKEN_TEST)
 
-.PHONY: static
 static:  # Check static types
 	uv run pyright
 
-.PHONY: unit
 unit:  # Run unit tests, eg: make unit ARGS='tests/unit/test_deploy.py'
 	uv run pytest tests/unit -vv --cov=jubilant $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -1,58 +1,53 @@
 
 .PHONY: help
-help:
+help:  # Display help
 	@echo "Usage: make [target] [ARGS='additional args']\n\nTargets:"
-	@awk -F: '/^[a-z-]+:/ { print "   ", $$1 }' Makefile
+	@awk -F'#' '/^[a-z-]+:/ { sub(":.*", "", $$1); print " ", $$1, "#", $$2 }' Makefile | column -t -s '#'
 
-# Run all quick, local commands
 .PHONY: all
-all: format lint static unit
+all: format lint static unit  # Run all quick, local commands
 
-# Build documentation
+.PHONE: coverage-html
+coverage-html:  # Write and open HTML coverage report from last unit test run
+	uv run coverage html
+	open htmlcov/index.html 2>/dev/null
+
 .PHONY: docs
-docs:
+docs:  # Build documentation
 	$(MAKE) -C docs run
 
-# Fix linting issues
 .PHONY: fix
-fix:
+fix:  # Fix linting issues
 	uv run ruff check --fix
 
-# Format the Python code
 .PHONY: format
-format:
+format:  # Format the Python code
 	uv run ruff format
 
-# Run integration tests (slow, require real Juju)
 .PHONY: integration
-integration:
+integration:  # Run integration tests on Juju, eg: make integration ARGS='-k test_deploy'
 	uv run pytest tests/integration -vv --log-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" $(ARGS)
 
-# Perform linting
 .PHONY: lint
-lint:
+lint:  # Perform linting
 	uv run ruff check
 	uv run ruff format --diff
 
-# Pack charms used by integration tests (requires charmcraft)
 .PHONY: pack
-pack:
+pack:  # Pack charms used by integration tests (requires charmcraft)
 	cd tests/integration/charms/testdb && charmcraft pack
 	cd tests/integration/charms/testapp && charmcraft pack
 
-# Publish to TestPyPI
 .PHONY:
-publish-test:
+publish-test:  # Publish to TestPyPI
 	rm -rf dist
 	uv build
 	uv publish --publish-url=https://test.pypi.org/legacy/ --token=$(UV_PUBLISH_TOKEN_TEST)
 
-# Check static types
 .PHONY: static
-static:
+static:  # Check static types
 	uv run pyright
 
-# Run quick unit tests
 .PHONY: unit
-unit:
+unit:  # Run unit tests, eg: make unit ARGS='tests/unit/test_deploy.py'
 	uv run pytest tests/unit -vv --cov=jubilant $(ARGS)

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -79,6 +79,9 @@ def test_charm_basics(juju: jubilant.Juju):
     assert task.return_code != 0
     assert 'EXC' in task.stderr
 
+    with pytest.raises(TimeoutError):
+        juju.run(charm + '/0', 'do-thing', wait=0.001)
+
     with pytest.raises(ValueError):
         juju.run(charm + '/0', 'action-not-defined')
     with pytest.raises(ValueError):
@@ -101,6 +104,9 @@ def test_charm_basics(juju: jubilant.Juju):
     assert not task.success
     assert task.stdout == ''
     assert 'invalid time' in task.stderr
+
+    with pytest.raises(TimeoutError):
+        juju.exec('sleep 1', unit=charm + '/0', wait=0.001)
 
     with pytest.raises(ValueError):
         juju.exec('echo foo', unit=charm + '/42')  # unit not found

--- a/tests/unit/test_exec.py
+++ b/tests/unit/test_exec.py
@@ -119,6 +119,30 @@ def test_failure_other_error(run: mocks.Run):
     assert excinfo.value.stderr == 'ERR'
 
 
+def test_wait_timeout(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'exec',
+            '--format',
+            'json',
+            '--unit',
+            'ubuntu/0',
+            '--wait',
+            '0.001s',
+            '--',
+            'sleep 1',
+        ],
+        returncode=1,
+        stdout='OUT',
+        stderr='... timed out ...',
+    )
+    juju = jubilant.Juju()
+
+    with pytest.raises(TimeoutError):
+        juju.exec('sleep 1', unit='ubuntu/0', wait=0.001)
+
+
 def test_machine_not_found(run: mocks.Run):
     run.handle(['juju', 'exec', '--format', 'json', '--machine', '0', '--', 'echo'])
     juju = jubilant.Juju()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -140,6 +140,19 @@ def test_exception_other(run: mocks.Run):
     assert excinfo.value.stderr == 'ERR'
 
 
+def test_wait_timeout(run: mocks.Run):
+    run.handle(
+        ['juju', 'run', '--format', 'json', 'mysql/0', 'do-thing', '--wait', '0.001s'],
+        returncode=1,
+        stdout='OUT',
+        stderr='... timed out ...',
+    )
+    juju = jubilant.Juju()
+
+    with pytest.raises(TimeoutError):
+        juju.run('mysql/0', 'do-thing', wait=0.001)
+
+
 @pytest.mark.parametrize('cli_binary', ['/snap/bin/juju', '/bin/juju'])
 def test_params(monkeypatch: pytest.MonkeyPatch, cli_binary: str):
     stdout = """


### PR DESCRIPTION
This adds support for the `--wait` argument on the `exec` and `run` methods, allowing you to specify a timeout when waiting for the task.

This PR also adds a `coverage-html` target to the Makefile, and updates the `help` target to show the comment for each target. Thanks James for the idea to use `column` [here](https://github.com/james-garner-canonical/charmlibs-pathops/pull/4/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52). Note also the addition of `MAKEFLAGS += "--always-make"`, avoiding the need for `.PHONY` on all targets.