### PR TITLE
feat: add remove_relation method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # We're using Make as a command runner, so always make (avoids need for .PHONY)
-MAKEFLAGS += "--always-make"
+MAKEFLAGS += --always-make
 
 help:  # Display help
 	@echo "Usage: make [target] [ARGS='additional args']\n\nTargets:"

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -456,6 +456,24 @@ class Juju:
                 args.extend(['--via', ','.join(via)])
         self.cli(*args)
 
+    def remove_relation(self, app1: str, app2: str, *, force: bool = False) -> None:
+        """Remove an existing relation between two applications (opposite of :meth:`integrate`).
+
+        The order of *app1* and *app2* is not significant. Each of them should
+        be in the format ``<application>[:<endpoint>]``. The endpoint is only
+        required if there's more than one possible integration between the two
+        applications.
+
+        Args:
+            app1: One of the applications (and endpoints) to integrate.
+            app2: The other of the applications (and endpoints) to integrate.
+            force: Force removal, ignoring operational errors.
+        """
+        args = ['remove-relation', app1, app2]
+        if force:
+            args.append('--force')
+        self.cli(*args)
+
     def remove_unit(
         self,
         app_or_unit: str | Iterable[str],

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -120,8 +120,17 @@ def test_integrate(juju: jubilant.Juju):
 
     juju.integrate('testdb', 'testapp')
     status = juju.wait(jubilant.all_active)
+    assert status.apps['testdb'].relations['db'][0].related_app == 'testapp'
+    assert status.apps['testapp'].relations['db'][0].related_app == 'testdb'
     assert status.apps['testdb'].app_status.message == 'relation created'
     assert status.apps['testapp'].app_status.message == 'relation changed: dbkey=dbvalue'
+
+    juju.remove_relation('testdb', 'testapp')
+    juju.wait(
+        lambda status: (
+            not status.apps['testdb'].relations and not status.apps['testapp'].relations
+        )
+    )
 
 
 def charm_path(name: str) -> pathlib.Path:

--- a/tests/unit/test_remove_relation.py
+++ b/tests/unit/test_remove_relation.py
@@ -1,0 +1,31 @@
+import jubilant
+
+from . import mocks
+
+
+def test(run: mocks.Run):
+    run.handle(['juju', 'remove-relation', 'app1', 'app2'])
+    juju = jubilant.Juju()
+
+    juju.remove_relation('app1', 'app2')
+
+
+def test_with_model(run: mocks.Run):
+    run.handle(['juju', 'remove-relation', '--model', 'mdl', 'app1', 'app2'])
+    juju = jubilant.Juju(model='mdl')
+
+    juju.remove_relation('app1', 'app2')
+
+
+def test_with_endpoints(run: mocks.Run):
+    run.handle(['juju', 'remove-relation', 'app1:db', 'app2:db'])
+    juju = jubilant.Juju()
+
+    juju.remove_relation('app1:db', 'app2:db')
+
+
+def test_force(run: mocks.Run):
+    run.handle(['juju', 'remove-relation', 'app1', 'app2', '--force'])
+    juju = jubilant.Juju()
+
+    juju.remove_relation('app1', 'app2', force=True)


### PR DESCRIPTION
Add the `Juju.remove_relation` method for removing a relation (the opposite of `integrate`). Type signature is similar to `integrate`.