### PR TITLE
feat: add offer command

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -456,6 +456,27 @@ class Juju:
                 args.extend(['--via', ','.join(via)])
         self.cli(*args)
 
+    def offer(self, app: str, endpoint: str | Iterable[str], *, name: str | None = None) -> None:
+        """Offer application endpoints for use in other models.
+
+        Args:
+            app: Application name to offer endpoints for.
+            endpoint: Endpoint or endpoints to offer, for example ``'db'`` or ``['db', 'log']``.
+            name: Name of the offer. By default, the offer is named after the application.
+        """
+        if ':' in app:
+            raise TypeError('must provide endpoint in "endpoint" argument not in "app"')
+
+        args = ['offer']
+        if isinstance(endpoint, str):
+            args.append(f'{app}:{endpoint}')
+        else:
+            args.append(f'{app}:{",".join(endpoint)}')
+        if name is not None:
+            args.append(name)
+
+        self.cli(*args)
+
     def remove_relation(self, app1: str, app2: str, *, force: bool = False) -> None:
         """Remove an existing relation between two applications (opposite of :meth:`integrate`).
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -463,22 +463,26 @@ class Juju:
                 args.extend(['--via', ','.join(via)])
         self.cli(*args)
 
-    def offer(self, app: str, endpoint: str | Iterable[str], *, name: str | None = None) -> None:
+    def offer(self, app: str, *endpoint: str, name: str | None = None) -> None:
         """Offer application endpoints for use in other models.
+
+        Examples::
+
+            juju.offer('mysql', 'db')
+            juju.offer('mymodel.mysql', 'db', 'log', name='altname')
 
         Args:
             app: Application name to offer endpoints for.
-            endpoint: Endpoint or endpoints to offer, for example ``'db'`` or ``['db', 'log']``.
+            endpoint: Endpoint or endpoints to offer.
             name: Name of the offer. By default, the offer is named after the application.
         """
         if ':' in app:
             raise TypeError('must provide endpoint in "endpoint" argument not in "app"')
+        if not endpoint:
+            raise TypeError('must provide at least one endpoint')
 
-        args = ['offer']
-        if isinstance(endpoint, str):
-            args.append(f'{app}:{endpoint}')
-        else:
-            args.append(f'{app}:{",".join(endpoint)}')
+        app_endpoint = app + ':' + ','.join(endpoint)
+        args = ['offer', app_endpoint]
         if name is not None:
             args.append(name)
 

--- a/tests/unit/test_offer.py
+++ b/tests/unit/test_offer.py
@@ -30,11 +30,13 @@ def test_multiple_endpoints(run: mocks.Run):
     run.handle(['juju', 'offer', 'mysql:db,log'])
     juju = jubilant.Juju()
 
-    juju.offer('mysql', ['db', 'log'])
+    juju.offer('mysql', 'db', 'log')
 
 
-def test_endpoint_in_app():
+def test_type_errors():
     juju = jubilant.Juju()
 
     with pytest.raises(TypeError):
-        juju.offer('mysql:db', 'name')
+        juju.offer('mysql:db', 'name')  # endpoint in "app" argument
+    with pytest.raises(TypeError):
+        juju.offer('mysql')  # no endpoint provided

--- a/tests/unit/test_offer.py
+++ b/tests/unit/test_offer.py
@@ -1,0 +1,40 @@
+import pytest
+
+import jubilant
+
+from . import mocks
+
+
+def test(run: mocks.Run):
+    run.handle(['juju', 'offer', 'mysql:db'])
+    juju = jubilant.Juju()
+
+    juju.offer('mysql', 'db')
+
+
+def test_with_model(run: mocks.Run):
+    run.handle(['juju', 'offer', '--model', 'mdl', 'mysql:db'])
+    juju = jubilant.Juju(model='mdl')
+
+    juju.offer('mysql', 'db')
+
+
+def test_name(run: mocks.Run):
+    run.handle(['juju', 'offer', 'mysql:db', 'nam'])
+    juju = jubilant.Juju()
+
+    juju.offer('mysql', 'db', name='nam')
+
+
+def test_multiple_endpoints(run: mocks.Run):
+    run.handle(['juju', 'offer', 'mysql:db,log'])
+    juju = jubilant.Juju()
+
+    juju.offer('mysql', ['db', 'log'])
+
+
+def test_endpoint_in_app():
+    juju = jubilant.Juju()
+
+    with pytest.raises(TypeError):
+        juju.offer('mysql:db', 'name')

--- a/tests/unit/test_wait.py
+++ b/tests/unit/test_wait.py
@@ -109,3 +109,13 @@ def test_timeout_override(run: mocks.Run, time: mocks.Time):
     assert len(run.calls) == 5
     assert time.monotonic() == 5
     assert 'mdl' in str(excinfo.value)
+
+
+def test_timeout_zero(time: mocks.Time):
+    juju = jubilant.Juju()
+
+    with pytest.raises(TimeoutError) as excinfo:
+        juju.wait(lambda _: False, timeout=0)
+
+    assert time.monotonic() == 0
+    assert 'mdl' not in str(excinfo.value)


### PR DESCRIPTION
This PR adds support for `juju offer`.

```python
def offer(self, app: str, *endpoint: str, name: str | None = None) -> None: ...

juju.offer('mysql', 'db', name='offr_name')
```

Fixes #9