### PR TITLE
feat: add "stdin" parameter to Juju.cli

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -161,25 +161,32 @@ class Juju:
 
         self.cli(*args)
 
-    def cli(self, *args: str, include_model: bool = True) -> str:
+    def cli(self, *args: str, include_model: bool = True, stdin: str | None = None) -> str:
         """Run a Juju CLI command and return its standard output.
 
         Args:
             args: Command-line arguments (excluding ``juju``).
             include_model: If true and :attr:`model` is set, insert the ``--model`` argument
                 after the first argument in *args*.
+            stdin: Standard input to send to the process, if any.
         """
-        stdout, _ = self._cli(*args, include_model=include_model)
+        stdout, _ = self._cli(*args, include_model=include_model, stdin=stdin)
         return stdout
 
-    def _cli(self, *args: str, include_model: bool = True) -> tuple[str, str]:
+    def _cli(
+        self, *args: str, include_model: bool = True, stdin: str | None = None
+    ) -> tuple[str, str]:
         """Run a Juju CLI command and return its standard output and standard error."""
         if include_model and self.model is not None:
             args = (args[0], '--model', self.model) + args[1:]
         logger.info('cli: juju %s', shlex.join(args))
         try:
             process = subprocess.run(
-                [self.cli_binary, *args], check=True, capture_output=True, encoding='utf-8'
+                [self.cli_binary, *args],
+                check=True,
+                capture_output=True,
+                encoding='utf-8',
+                input=stdin,
             )
         except subprocess.CalledProcessError as e:
             raise CLIError(e.returncode, e.cmd, e.stdout, e.stderr) from None

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -32,12 +32,12 @@ def test_add_and_remove_unit(juju: jubilant.Juju):
     juju.wait(lambda status: jubilant.all_active(status) and len(status.apps[charm].units) == 1)
 
 
-# Tests config get, config set, run, and exec
+# Tests config get, config set, trust, run, exec, and cli with input
 def test_charm_basics(juju: jubilant.Juju):
     charm = 'testdb'
     juju.deploy(charm_path(charm))
 
-    # unit should come up as "unknown"
+    # Unit should come up as "unknown"
     juju.wait(
         lambda status: status.apps[charm].units[charm + '/0'].workload_status.current == 'unknown'
     )
@@ -120,6 +120,10 @@ def test_charm_basics(juju: jubilant.Juju):
         juju.exec('echo foo', unit=charm + '/42')  # unit not found
     with pytest.raises(jubilant.CLIError):
         juju.exec('echo foo', machine=0)  # unable to target machines with a k8s controller
+
+    # Test cli with input
+    stdout = juju.cli('ssh', '--container', 'charm', charm + '/0', 'cat', stdin='foo')
+    assert stdout == 'foo'
 
 
 def test_integrate(juju: jubilant.Juju):

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -47,7 +47,9 @@ class Run:
         assert args_tuple in self._commands, f'unhandled command {args}'
 
         returncode, stdout, stderr = self._commands[args_tuple]
-        self.calls.append(Call(args_tuple, returncode, input, stdout, stderr))
+        self.calls.append(
+            Call(args=args_tuple, returncode=returncode, stdin=input, stdout=stdout, stderr=stderr)
+        )
         if returncode != 0:
             raise subprocess.CalledProcessError(
                 returncode=returncode,

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -8,6 +8,7 @@ import subprocess
 class Call:
     args: tuple[str, ...]
     returncode: int
+    stdin: str | None
     stdout: str
     stderr: str
 
@@ -37,6 +38,7 @@ class Run:
         check: bool = False,
         capture_output: bool = False,
         encoding: str | None = None,
+        input: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         args_tuple = tuple(args)
         assert check is True
@@ -45,7 +47,7 @@ class Run:
         assert args_tuple in self._commands, f'unhandled command {args}'
 
         returncode, stdout, stderr = self._commands[args_tuple]
-        self.calls.append(Call(args_tuple, returncode, stdout, stderr))
+        self.calls.append(Call(args_tuple, returncode, input, stdout, stderr))
         if returncode != 0:
             raise subprocess.CalledProcessError(
                 returncode=returncode,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -79,3 +79,13 @@ def test_exclude_model_with_model(run: mocks.Run):
     stdout = juju.cli('test', include_model=False)
 
     assert stdout == 'OUT'
+
+
+def test_stdin(run: mocks.Run):
+    run.handle(['juju', 'ssh', 'mysql/0', 'pg_restore ...'], stdout='restored\n')
+    juju = jubilant.Juju()
+
+    stdout = juju.cli('ssh', 'mysql/0', 'pg_restore ...', stdin='PASSWORD')
+
+    assert stdout == 'restored\n'
+    assert run.calls[0].stdin == 'PASSWORD'


### PR DESCRIPTION
This adds the ability to send standard input to `Juju.cli`, for things like sending Postgres passwords to `scp` and `ssh`.