### PR TITLE
fix: don't log "juju status" calls in Juju.wait()

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -685,7 +685,9 @@ class Juju:
             status = Status._from_dict(result)
 
             if status != prev_status:
-                logger.info('wait: status changed:\n%s', _status_diff(prev_status, status))
+                diff = _status_diff(prev_status, status)
+                if diff:
+                    logger.info('wait: status changed:\n%s', diff)
 
             if error is not None and error(status):
                 raise WaitError(f'error function {error.__qualname__} returned false\n{status}')

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -174,12 +174,13 @@ class Juju:
         return stdout
 
     def _cli(
-        self, *args: str, include_model: bool = True, stdin: str | None = None
+        self, *args: str, include_model: bool = True, stdin: str | None = None, log: bool = True
     ) -> tuple[str, str]:
         """Run a Juju CLI command and return its standard output and standard error."""
         if include_model and self.model is not None:
             args = (args[0], '--model', self.model) + args[1:]
-        logger.info('cli: juju %s', shlex.join(args))
+        if log:
+            logger.info('cli: juju %s', shlex.join(args))
         try:
             process = subprocess.run(
                 [self.cli_binary, *args],
@@ -678,7 +679,11 @@ class Juju:
 
         while time.monotonic() - start < timeout:
             prev_status = status
-            status = self.status()
+
+            stdout, _ = self._cli('status', '--format', 'json', log=False)
+            result = json.loads(stdout)
+            status = Status._from_dict(result)
+
             if status != prev_status:
                 logger.info('wait: status changed:\n%s', _status_diff(prev_status, status))
 

--- a/tests/unit/test_wait.py
+++ b/tests/unit/test_wait.py
@@ -26,9 +26,8 @@ def test_logging(run: mocks.Run, time: mocks.Time, caplog: pytest.LogCaptureFixt
 
     juju.wait(lambda _: True)
 
-    logs = [r for r in caplog.records if r.msg.startswith('wait:')]
-    assert len(logs) == 1  # only logs on first call or when status changes
-    message = logs[0].getMessage()
+    assert len(caplog.records) == 1  # only logs on first call or when status changes
+    message = caplog.records[0].getMessage()
     assert (
         message
         == """wait: status changed:


### PR DESCRIPTION
This removes the logging of every `cli: juju status ...` call while polling status in `Juju.wait` sequences.

Also removes certain "glitches" where it'd show a status change when only `.since` timestamp lines changed, and would result in blank lines like this:

```
INFO wait: status changed:

INFO ... more logs ...
```

Fix #86 