### PR TITLE
fix!: change remove_unit to use *args

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -508,8 +508,7 @@ class Juju:
             force: Force removal even if a unit is in an error state.
             num_units: Number of units to remove (Kubernetes models only).
         """
-        args = ['remove-unit', '--no-prompt']
-        args.extend(app_or_unit)
+        args = ['remove-unit', '--no-prompt', *app_or_unit]
 
         if destroy_storage:
             args.append('--destroy-storage')

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -483,8 +483,7 @@ class Juju:
 
     def remove_unit(
         self,
-        app_or_unit: str | Iterable[str],
-        *,
+        *app_or_unit: str,
         destroy_storage: bool = False,
         force: bool = False,
         num_units: int = 0,
@@ -498,7 +497,7 @@ class Juju:
 
             # Machine model:
             juju.remove_unit('wordpress/1')
-            juju.remove_unit(['wordpress/2', 'wordpress/3'])
+            juju.remove_unit('wordpress/2', 'wordpress/3')
 
         Args:
             app_or_unit: On machine models, this is the name of the unit or units to remove.
@@ -510,17 +509,14 @@ class Juju:
             num_units: Number of units to remove (Kubernetes models only).
         """
         args = ['remove-unit', '--no-prompt']
-        if isinstance(app_or_unit, str):
-            args.append(app_or_unit)
-        else:
-            args.extend(app_or_unit)
+        args.extend(app_or_unit)
 
         if destroy_storage:
             args.append('--destroy-storage')
         if force:
             args.append('--force')
         if num_units:
-            if not isinstance(app_or_unit, str):
+            if len(app_or_unit) > 1:
                 raise TypeError('"app_or_unit" must be a single app name if num_units specified')
             args.extend(['--num-units', str(num_units)])
 

--- a/tests/unit/test_remove_unit.py
+++ b/tests/unit/test_remove_unit.py
@@ -37,11 +37,18 @@ def test_multiple(run: mocks.Run):
     run.handle(['juju', 'remove-unit', '--no-prompt', 'unit/0', 'unit/1', 'unit/2'])
     juju = jubilant.Juju()
 
-    juju.remove_unit(['unit/0', 'unit/1', 'unit/2'])
+    juju.remove_unit('unit/0', 'unit/1', 'unit/2')
 
 
-def test_multiple_num_units_error():
+def test_two_units_error():
     juju = jubilant.Juju()
 
     with pytest.raises(TypeError):
-        juju.remove_unit(['unit/0', 'unit/1', 'unit/2'], num_units=3)
+        juju.remove_unit('unit/0', 'unit/1', num_units=2)
+
+
+def test_three_units_error():
+    juju = jubilant.Juju()
+
+    with pytest.raises(TypeError):
+        juju.remove_unit('unit/0', 'unit/1', 'unit/2', num_units=3)


### PR DESCRIPTION
This PR changes the signature of `Juju.remove_unit` to use `*args` instead of distinguishing between a string or an iterable. This matches the approach for `Juju.exec`.

I've added an extra unit test to guard against an off-by-one error.