### PR TITLE
feat: add ssh command

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -671,6 +671,10 @@ class Juju:
             ssh_options: OpenSSH client options, for example ``['-i', '/path/to/private.key']``.
             user: User account to make connection with. Defaults to ``ubuntu`` account.
         """
+        # Need this check because str is also an iterable of str.
+        if isinstance(ssh_options, str):
+            raise TypeError('ssh_options must be an iterable of str, not str')
+
         cli_args = ['ssh']
         if container is not None:
             cli_args.extend(['--container', container])

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -20,11 +20,11 @@ def test_deploy(juju: jubilant.Juju):
     assert 'snappass' in response.text.lower()
 
     # Test ssh with --container argument
-    output = juju.ssh('ls', '/charm/containers', unit='snappass-test/0')
+    output = juju.ssh('snappass-test/0', 'ls', '/charm/containers')
     assert output.split() == ['redis', 'snappass']
-    output = juju.ssh('ls', '/charm/container', unit='snappass-test/0', container='snappass')
+    output = juju.ssh('snappass-test/0', 'ls', '/charm/container', container='snappass')
     assert 'pebble' in output.split()
-    output = juju.ssh('ls', '/charm/container', unit='snappass-test/0', container='redis')
+    output = juju.ssh('snappass-test/0', 'ls', '/charm/container', container='redis')
     assert 'pebble' in output.split()
 
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -19,6 +19,14 @@ def test_deploy(juju: jubilant.Juju):
     assert '<title>' in response.text
     assert 'snappass' in response.text.lower()
 
+    # Test ssh with --container argument
+    output = juju.ssh('ls', '/charm/containers', unit='snappass-test/0')
+    assert output.split() == ['redis', 'snappass']
+    output = juju.ssh('ls', '/charm/container', unit='snappass-test/0', container='snappass')
+    assert 'pebble' in output.split()
+    output = juju.ssh('ls', '/charm/container', unit='snappass-test/0', container='redis')
+    assert 'pebble' in output.split()
+
 
 def test_add_and_remove(juju: jubilant.Juju):
     charm = 'snappass-test'

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -9,7 +9,7 @@ def test_machine(run: mocks.Run):
     run.handle(['juju', 'ssh', '1', 'echo bar'], stdout='bar\n')
     juju = jubilant.Juju()
 
-    output = juju.ssh('echo bar', machine=1)
+    output = juju.ssh(1, 'echo bar')
     assert output == 'bar\n'
 
 
@@ -17,7 +17,7 @@ def test_unit(run: mocks.Run):
     run.handle(['juju', 'ssh', 'ubuntu/0', 'echo', 'foo'], stdout='foo\n')
     juju = jubilant.Juju()
 
-    output = juju.ssh('echo', 'foo', unit='ubuntu/0')
+    output = juju.ssh('ubuntu/0', 'echo', 'foo')
     assert output == 'foo\n'
 
 
@@ -28,7 +28,7 @@ def test_container(run: mocks.Run):
     )
     juju = jubilant.Juju()
 
-    output = juju.ssh('echo', 'foo', unit='snappass-test/0', container='snappass')
+    output = juju.ssh('snappass-test/0', 'echo', 'foo', container='snappass')
     assert output == 'foo\n'
 
 
@@ -36,7 +36,7 @@ def test_user(run: mocks.Run):
     run.handle(['juju', 'ssh', 'usr@ubuntu/0', 'echo', 'foo'], stdout='foo\n')
     juju = jubilant.Juju()
 
-    output = juju.ssh('echo', 'foo', unit='ubuntu/0', user='usr')
+    output = juju.ssh('ubuntu/0', 'echo', 'foo', user='usr')
     assert output == 'foo\n'
 
 
@@ -57,9 +57,9 @@ def test_ssh_options(run: mocks.Run):
     juju = jubilant.Juju()
 
     output = juju.ssh(
+        'ubuntu/0',
         'echo',
         'foo',
-        unit='ubuntu/0',
         host_key_checks=False,
         ssh_options=['-i', '/path/to/private.key'],
     )
@@ -71,7 +71,3 @@ def test_type_errors():
 
     with pytest.raises(TypeError):
         juju.ssh('cmd')
-    with pytest.raises(TypeError):
-        juju.ssh('cmd', unit='ubuntu/0', machine=0)
-    with pytest.raises(TypeError):
-        juju.ssh(unit='ubuntu/0')

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -1,0 +1,77 @@
+import pytest
+
+import jubilant
+
+from . import mocks
+
+
+def test_machine(run: mocks.Run):
+    run.handle(['juju', 'ssh', '1', 'echo bar'], stdout='bar\n')
+    juju = jubilant.Juju()
+
+    output = juju.ssh('echo bar', machine=1)
+    assert output == 'bar\n'
+
+
+def test_unit(run: mocks.Run):
+    run.handle(['juju', 'ssh', 'ubuntu/0', 'echo', 'foo'], stdout='foo\n')
+    juju = jubilant.Juju()
+
+    output = juju.ssh('echo', 'foo', unit='ubuntu/0')
+    assert output == 'foo\n'
+
+
+def test_container(run: mocks.Run):
+    run.handle(
+        ['juju', 'ssh', '--container', 'snappass', 'snappass-test/0', 'echo', 'foo'],
+        stdout='foo\n',
+    )
+    juju = jubilant.Juju()
+
+    output = juju.ssh('echo', 'foo', unit='snappass-test/0', container='snappass')
+    assert output == 'foo\n'
+
+
+def test_user(run: mocks.Run):
+    run.handle(['juju', 'ssh', 'usr@ubuntu/0', 'echo', 'foo'], stdout='foo\n')
+    juju = jubilant.Juju()
+
+    output = juju.ssh('echo', 'foo', unit='ubuntu/0', user='usr')
+    assert output == 'foo\n'
+
+
+def test_ssh_options(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'ssh',
+            '--no-host-key-checks',
+            'ubuntu/0',
+            '-i',
+            '/path/to/private.key',
+            'echo',
+            'foo',
+        ],
+        stdout='foo\n',
+    )
+    juju = jubilant.Juju()
+
+    output = juju.ssh(
+        'echo',
+        'foo',
+        unit='ubuntu/0',
+        host_key_checks=False,
+        ssh_options=['-i', '/path/to/private.key'],
+    )
+    assert output == 'foo\n'
+
+
+def test_type_errors():
+    juju = jubilant.Juju()
+
+    with pytest.raises(TypeError):
+        juju.ssh('cmd')
+    with pytest.raises(TypeError):
+        juju.ssh('cmd', unit='ubuntu/0', machine=0)
+    with pytest.raises(TypeError):
+        juju.ssh(unit='ubuntu/0')

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -1,3 +1,5 @@
+import pytest
+
 import jubilant
 
 from . import mocks
@@ -62,3 +64,10 @@ def test_ssh_options(run: mocks.Run):
         ssh_options=['-i', '/path/to/private.key'],
     )
     assert output == 'foo\n'
+
+
+def test_type_errors():
+    juju = jubilant.Juju()
+
+    with pytest.raises(TypeError):
+        juju.ssh('ubuntu/0', 'ls', ssh_options='invalid')

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -1,5 +1,3 @@
-import pytest
-
 import jubilant
 
 from . import mocks
@@ -64,10 +62,3 @@ def test_ssh_options(run: mocks.Run):
         ssh_options=['-i', '/path/to/private.key'],
     )
     assert output == 'foo\n'
-
-
-def test_type_errors():
-    juju = jubilant.Juju()
-
-    with pytest.raises(TypeError):
-        juju.ssh('cmd')


### PR DESCRIPTION
This PR adds support for "juju ssh":

    def ssh(
        self,
        target: str | int,
        command: str,
        *args: str,
        container: str | None = None,
        host_key_checks: bool = True,
        ssh_options: Iterable[str] = (),
        user: str | None = None,
    ) -> str:

    >>> juju.ssh('snappass-test/0', 'echo', 'foo')
    'foo\n'

The "user" is a separate argument, not stuffed into the target as on the CLI.

One decision point was the host_key_checks argument. I lean towards what I have here, but we could also do `no_host_key_checks: bool = False`, which is more 1:1 with the CLI. It just felt weird to have an inverted "no_foo" parameter when we can just invert the default in Python.

Fixes #14