### PR TITLE
feat: add refresh command

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -488,6 +488,61 @@ class Juju:
 
         self.cli(*args)
 
+    def refresh(
+        self,
+        app: str,
+        *,
+        base: str | None = None,
+        channel: str | None = None,
+        config: Mapping[str, ConfigValue] | None = None,
+        force: bool = False,
+        path: str | None = None,
+        resources: Mapping[str, str] | None = None,
+        revision: int | None = None,
+        storage: Mapping[str, str] | None = None,
+        trust: bool = False,
+    ):
+        """Refresh (upgrade) an application's charm.
+
+        Args:
+            app: Name of application to refresh.
+            base: Select a different base than is currently running.
+            channel: Channel to use when deploying from Charmhub, for example, ``latest/edge``.
+            config: Application configuration as key-value pairs.
+            force: If true, bypass checks such as supported bases.
+            path: Refresh to a charm located at this path.
+            resources: Specify named resources to use for deployment, for example:
+                ``{'bin': '/path/to/some/binary'}``.
+            revision: Charmhub revision number to deploy.
+            storage: Constraints for named storage(s), for example, ``{'data': 'tmpfs,1G'}``.
+            trust: If true, allows charm to run hooks that require access to cloud credentials.
+        """
+        args = ['refresh', app]
+
+        if base is not None:
+            args.extend(['--base', base])
+        if channel is not None:
+            args.extend(['--channel', channel])
+        if config is not None:
+            for k, v in config.items():
+                args.extend(['--config', _format_config(k, v)])
+        if force:
+            args.extend(['--force', '--force-base', '--force-units'])
+        if path is not None:
+            args.extend(['--path', path])
+        if resources is not None:
+            for k, v in resources.items():
+                args.extend(['--resource', f'{k}={v}'])
+        if revision is not None:
+            args.extend(['--revision', str(revision)])
+        if storage is not None:
+            for k, v in storage.items():
+                args.extend(['--storage', f'{k}={v}'])
+        if trust:
+            args.append('--trust')
+
+        self.cli(*args)
+
     def remove_application(
         self,
         *app: str,

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -19,6 +19,9 @@ def test_deploy(juju: jubilant.Juju):
     assert '<title>' in response.text
     assert 'snappass' in response.text.lower()
 
+    # Ensure refresh works (though it will already be up to date)
+    juju.refresh('snappass-test')
+
 
 def test_add_and_remove(juju: jubilant.Juju):
     charm = 'snappass-test'

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -1,0 +1,63 @@
+import jubilant
+
+from . import mocks
+
+
+def test_defaults(run: mocks.Run):
+    run.handle(['juju', 'refresh', 'xyz'])
+    juju = jubilant.Juju()
+
+    juju.refresh('xyz')
+
+
+def test_defaults_with_model(run: mocks.Run):
+    run.handle(['juju', 'refresh', '--model', 'mdl', 'xyz'])
+    juju = jubilant.Juju(model='mdl')
+
+    juju.refresh('xyz')
+
+
+def test_all_args(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'refresh',
+            'app',
+            '--base',
+            'ubuntu@22.04',
+            '--channel',
+            'latest/edge',
+            '--config',
+            'x=true',
+            '--config',
+            'y=1',
+            '--config',
+            'z=ss',
+            '--force',
+            '--force-base',
+            '--force-units',
+            '--path',
+            '/path/to/app.charm',
+            '--resource',
+            'bin=/path',
+            '--revision',
+            '42',
+            '--storage',
+            'data=tmpfs,1G',
+            '--trust',
+        ]
+    )
+    juju = jubilant.Juju()
+
+    juju.refresh(
+        'app',
+        base='ubuntu@22.04',
+        channel='latest/edge',
+        config={'x': True, 'y': 1, 'z': 'ss'},
+        force=True,
+        path='/path/to/app.charm',
+        resources={'bin': '/path'},
+        revision=42,
+        storage={'data': 'tmpfs,1G'},
+        trust=True,
+    )


### PR DESCRIPTION
This PR adds support for `juju refresh`. The arguments are very similar to `Juju.deploy`.

Nothing too controversial here. The one thing that differs from the CLI is that I've stuffed all the "force_*" arguments under one, so `force=True` becomes `--force --force-base --force-units`. It seems to me that if you want to force and bypass checks, you want to force, and it saves a proliferation of arguments.

    def refresh(
        self,
        app: str,
        *,
        base: str | None = None,
        channel: str | None = None,
        config: Mapping[str, ConfigValue] | None = None,
        force: bool = False,
        path: str | None = None,
        resources: Mapping[str, str] | None = None,
        revision: int | None = None,
        storage: Mapping[str, str] | None = None,
        trust: bool = False,
    ):

    >>> juju.refresh('snappass-test')
    >>>

Fixes #10