### PR TITLE
feat: slightly more helpful TaskError.__str__

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('jubilant')
 class CLIError(subprocess.CalledProcessError):
     """Subclass of ``CalledProcessError`` that includes stdout and stderr in the ``__str__``."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = super().__str__()
         if self.stdout:
             s += '\nStdout:\n' + self.stdout

--- a/jubilant/_task.py
+++ b/jubilant/_task.py
@@ -16,10 +16,7 @@ class TaskError(Exception):
         self.task = task
 
     def __str__(self) -> str:
-        return (
-            f'task {self.task.id} failed with status {self.task.status!r} '
-            + f'and return code {self.task.return_code}\n{_pretty.dump(self.task)}'
-        )
+        return f'task error: {self.task}'
 
 
 @dataclasses.dataclass(frozen=True)
@@ -53,6 +50,27 @@ class Task:
 
     log: list[str] = dataclasses.field(default_factory=list)
     """List of messages logged by the action hook."""
+
+    def __str__(self) -> str:
+        details: list[str] = []
+        if self.results:
+            details.append(f'Results: {self.results}')
+        if self.stdout:
+            details.append(f'Stdout:\n{self.stdout}')
+        if self.stderr:
+            details.append(f'Stderr:\n{self.stderr}')
+        if self.message:
+            details.append(f'Message: {self.message}')
+        if self.log:
+            log_str = '\n'.join(self.log)
+            details.append(f'Log:\n{log_str}')
+        s = f'Task {self.id}: status {self.status!r}, return code {self.return_code}'
+        if details:
+            s += ', details:\n' + '\n'.join(details)
+        return s
+
+    def __repr__(self) -> str:
+        return _pretty.dump(self)
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> Task:

--- a/jubilant/_task.py
+++ b/jubilant/_task.py
@@ -3,6 +3,24 @@ from __future__ import annotations
 import dataclasses
 from typing import Any, Literal
 
+from . import _pretty
+
+
+class TaskError(Exception):
+    """Exception raised when an action or exec command fails."""
+
+    task: Task
+    """Associated task."""
+
+    def __init__(self, task: Task):
+        self.task = task
+
+    def __str__(self) -> str:
+        return (
+            f'task {self.task.id} failed with status {self.task.status!r} '
+            + f'and return code {self.task.return_code}\n{_pretty.dump(self.task)}'
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class Task:
@@ -62,13 +80,3 @@ class Task:
         """If task was not successful, raise a :class:`TaskError`."""
         if not self.success:
             raise TaskError(self)
-
-
-class TaskError(Exception):
-    """Exception raised when an action or exec command fails."""
-
-    task: Task
-    """Associated task."""
-
-    def __init__(self, task: Task):
-        self.task = task

--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -739,11 +739,11 @@ class Status:
             ),
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return a pretty-printed version of the status."""
         return _pretty.dump(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return a pretty-printed version of the status."""
         return repr(self)
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -89,10 +89,6 @@ def test_failure(run: mocks.Run):
     )
     assert not excinfo.value.task.success
 
-    exc_str = str(excinfo.value)
-    assert exc_str.startswith("task 42 failed with status 'failed' and return code 0")
-    assert "message='Failure message'" in exc_str
-
 
 def test_exception_task_failed(run: mocks.Run):
     out_json = """

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -89,6 +89,10 @@ def test_failure(run: mocks.Run):
     )
     assert not excinfo.value.task.success
 
+    exc_str = str(excinfo.value)
+    assert exc_str.startswith("task 42 failed with status 'failed' and return code 0")
+    assert "message='Failure message'" in exc_str
+
 
 def test_exception_task_failed(run: mocks.Run):
     out_json = """

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,0 +1,69 @@
+import pytest
+
+import jubilant
+
+
+def test_task_success():
+    task = jubilant.Task(id='42', status='completed', return_code=0)
+    assert task.success
+
+    task = jubilant.Task(id='42', status='completed', return_code=1)
+    assert not task.success
+
+    task = jubilant.Task(id='42', status='failed', return_code=0)
+    assert not task.success
+
+    task = jubilant.Task(id='42', status='failed', return_code=1)
+    assert not task.success
+
+
+def test_task_raise_on_failure():
+    task = jubilant.Task(id='42', status='completed', return_code=0)
+    task.raise_on_failure()
+
+    task = jubilant.Task(id='42', status='completed', return_code=1)
+    with pytest.raises(jubilant.TaskError):
+        task.raise_on_failure()
+
+
+def test_task_str_minimal():
+    task = jubilant.Task(id='42', status='completed')
+    assert str(task) == "Task 42: status 'completed', return code 0"
+
+
+def test_task_str_full():
+    task = jubilant.Task(
+        id='1',
+        status='failed',
+        results={'foo': 'bar'},
+        return_code=3,
+        stdout='STDOUT',
+        stderr='STDERR',
+        message='Some kind of failure',
+        log=['LOG 1', 'LOG 2'],
+    )
+    assert (
+        str(task)
+        == """\
+Task 1: status 'failed', return code 3, details:
+Results: {'foo': 'bar'}
+Stdout:
+STDOUT
+Stderr:
+STDERR
+Message: Some kind of failure
+Log:
+LOG 1
+LOG 2"""
+    )
+
+
+def test_task_repr():
+    task = jubilant.Task(id='42', status='completed')
+    assert eval(repr(task), {'Task': jubilant.Task}) == task
+
+
+def test_task_error_str():
+    task = jubilant.Task(id='42', status='completed')
+    exc = jubilant.TaskError(task)
+    assert str(exc) == 'task error: ' + str(task)


### PR DESCRIPTION
It actually wasn't as bad as I thought in #97, because the default `Exception.__str__` is just the str of the args, so the traceback looked like this:

```
jubilant._task.TaskError: Task(id='42', status='failed', ...)
```

However, this adds a human-readable first line, and pretty-prints the task dataclass:

```
jubilant._task.TaskError: task errror: Task 42, status 'failed', return code 1, details:
Stdout:
STDOUT
Stderr:
STDERR
Message: Some kind of failure
```

Fixes #97