### PR TITLE
fix: Do not crash on Juju 2.9 status format

### DIFF
--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -85,6 +85,8 @@ class AppStatusRelation:
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> AppStatusRelation:
+        if not hasattr(d, 'get'):
+            return cls()
         return cls(
             related_app=d.get('related-application') or '',
             interface=d.get('interface') or '',

--- a/tests/unit/fake_statuses.py
+++ b/tests/unit/fake_statuses.py
@@ -218,3 +218,70 @@ DATABASE_WEBAPP_JSON = """
     }
 }
 """
+
+JUJU29_JSON = """
+{
+    "model": {
+        "name": "jubilant-0b6f94f3",
+        "type": "caas",
+        "controller": "microk8s-localhost",
+        "cloud": "microk8s",
+        "region": "localhost",
+        "version": "2.9.51",
+        "model-status": {
+            "current": "available",
+            "since": "16 Apr 2025 20:40:45Z"
+        },
+        "sla": "unsupported"
+    },
+    "machines": {},
+    "applications": {
+        "tls-certificates-requirer": {
+            "charm": "local:jammy/tls-certificates-requirer-0",
+            "series": "jammy",
+            "os": "ubuntu",
+            "charm-origin": "local",
+            "charm-name": "tls-certificates-requirer",
+            "charm-rev": 0,
+            "scale": 1,
+            "provider-id": "f995d1da-c34b-4d33-afcd-561b848dd8b9",
+            "address": "10.152.183.114",
+            "exposed": false,
+            "application-status": {
+                "current": "waiting",
+                "message": "installing agent",
+                "since": "16 Apr 2025 20:46:20Z"
+            },
+            "relations": {
+                "replicas": [
+                    "tls-certificates-requirer"
+                ]
+            },
+            "units": {
+                "tls-certificates-requirer/0": {
+                    "workload-status": {
+                        "current": "waiting",
+                        "message": "installing agent",
+                        "since": "16 Apr 2025 20:46:20Z"
+                    },
+                    "juju-status": {
+                        "current": "allocating",
+                        "since": "16 Apr 2025 20:46:14Z"
+                    },
+                    "address": "10.1.216.142",
+                    "provider-id": "tls-certificates-requirer-0"
+                }
+            },
+            "endpoint-bindings": {
+                "": "alpha",
+                "certificates": "alpha",
+                "replicas": "alpha"
+            }
+        }
+    },
+    "storage": {},
+    "controller": {
+        "timestamp": "20:46:20Z"
+    }
+}
+"""

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -4,7 +4,7 @@ import jubilant
 from jubilant import statustypes
 
 from . import mocks
-from .fake_statuses import MINIMAL_JSON, MINIMAL_STATUS, SNAPPASS_JSON
+from .fake_statuses import JUJU29_JSON, MINIMAL_JSON, MINIMAL_STATUS, SNAPPASS_JSON
 
 
 def test_minimal(run: mocks.Run):
@@ -50,3 +50,15 @@ def test_status_eq():
     )
     assert status1 == status1b
     assert status1 == status2
+
+
+def test_juju_2_9_status(run: mocks.Run):
+    run.handle(['juju', 'status', '--format', 'json'], stdout=JUJU29_JSON)
+    juju = jubilant.Juju()
+
+    status = juju.status()
+
+    assert status.model.type == 'caas'
+    assert status.apps['tls-certificates-requirer'].is_waiting
+    assert status.apps['tls-certificates-requirer'].units['tls-certificates-requirer/0'].is_waiting
+    assert not status.apps['tls-certificates-requirer'].units['tls-certificates-requirer/0'].leader


### PR DESCRIPTION
This PR prevents Jubilant from crashing when fed a status from Juju 2.9. We have a suite of integration tests that need to work with that version of Juju as it is still supported, and this prevents using Jubilant for those tests.

I am aware that the rest of the API is not compatible with that version of Juju, but working directly with `juju.cli()` is feasible in our case. The only blocker is Jubilant crashing when parsing the `relations` in the status output.