### PR TITLE
ci: test deploy with resources (and base)

### DIFF
--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -46,7 +46,7 @@ def test_deploy_with_resources(juju: jubilant.Juju):
     juju.deploy(
         'snappass-test',
         'snappass-with-resources',
-        base='ubuntu@22.04',
+        base='ubuntu@20.04',
         resources={
             'snappass-image': 'benhoyt/snappass-test',
             'redis-image': 'redis',

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -40,3 +40,16 @@ def test_add_and_remove_unit(juju: jubilant.Juju):
 def test_remove_application(juju: jubilant.Juju):
     juju.remove_application('snappass-test')
     juju.wait(lambda status: not status.apps)
+
+
+def test_deploy_with_resources(juju: jubilant.Juju):
+    juju.deploy(
+        'snappass-test',
+        'snappass-with-resources',
+        base='ubuntu@22.04',
+        resources={
+            'snappass-image': 'benhoyt/snappass-test',
+            'redis-image': 'redis',
+        },
+    )
+    juju.wait(lambda status: status.apps['snappass-with-resources'].is_active)


### PR DESCRIPTION
Just adds an integration test for `juju deploy` with `--resource`.

Fixes #75. Most high-level features are covered by integration tests now. Not all arguments, but I think this is enough for now.