### PR TITLE
feat: add scp command

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -703,6 +703,36 @@ class Juju:
             if params_file is not None:
                 os.remove(params_file.name)
 
+    def scp(
+        self,
+        source: str,
+        destination: str,
+        *,
+        container: str | None = None,
+        host_key_checks: bool = True,
+        scp_options: Iterable[str] = (),
+    ) -> None:
+        """Securely transfer files within a model.
+
+        Args:
+            source: Source of file, in format ``[[<user>@]<target>:]<path>``.
+            destination: Destination for file, in format ``[<user>@]<target>:[<path>]``.
+            container: Name of container for Kubernetes charms. Defaults to the charm container.
+            host_key_checks: Set to False to disable host key checking (insecure).
+            scp_options: ``scp`` client options, for example ``['-r', '-C']``.
+        """
+        args = ['scp']
+        if container is not None:
+            args.extend(['--container', container])
+        if not host_key_checks:
+            args.append('--no-host-key-checks')
+        args.append('--')
+        args.extend(scp_options)
+        args.append(source)
+        args.append(destination)
+
+        self.cli(*args)
+
     def ssh(
         self,
         target: str | int,

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -4,6 +4,7 @@ import functools
 import json
 import logging
 import os
+import pathlib
 import shlex
 import shutil
 import subprocess
@@ -78,7 +79,7 @@ class Juju:
         *,
         model: str | None = None,
         wait_timeout: float = 3 * 60.0,
-        cli_binary: str | os.PathLike[str] | None = None,
+        cli_binary: str | pathlib.Path | None = None,
     ):
         self.model = model
         self.wait_timeout = wait_timeout
@@ -254,7 +255,7 @@ class Juju:
 
     def deploy(
         self,
-        charm: str | os.PathLike[str],
+        charm: str | pathlib.Path,
         app: str | None = None,
         *,
         attach_storage: str | Iterable[str] | None = None,
@@ -502,7 +503,7 @@ class Juju:
         channel: str | None = None,
         config: Mapping[str, ConfigValue] | None = None,
         force: bool = False,
-        path: str | None = None,
+        path: str | pathlib.Path | None = None,
         resources: Mapping[str, str] | None = None,
         revision: int | None = None,
         storage: Mapping[str, str] | None = None,
@@ -535,7 +536,7 @@ class Juju:
         if force:
             args.extend(['--force', '--force-base', '--force-units'])
         if path is not None:
-            args.extend(['--path', path])
+            args.extend(['--path', str(path)])
         if resources is not None:
             for k, v in resources.items():
                 args.extend(['--resource', f'{k}={v}'])
@@ -705,8 +706,8 @@ class Juju:
 
     def scp(
         self,
-        source: str,
-        destination: str,
+        source: str | pathlib.Path,
+        destination: str | pathlib.Path,
         *,
         container: str | None = None,
         host_key_checks: bool = True,
@@ -716,7 +717,7 @@ class Juju:
 
         Args:
             source: Source of file, in format ``[[<user>@]<target>:]<path>``.
-            destination: Destination for file, in format ``[<user>@]<target>:[<path>]``.
+            destination: Destination for file, in format ``[<user>@]<target>[:<path>]``.
             container: Name of container for Kubernetes charms. Defaults to the charm container.
             host_key_checks: Set to False to disable host key checking (insecure).
             scp_options: ``scp`` client options, for example ``['-r', '-C']``.
@@ -728,8 +729,8 @@ class Juju:
             args.append('--no-host-key-checks')
         args.append('--')
         args.extend(scp_options)
-        args.append(source)
-        args.append(destination)
+        args.append(str(source))
+        args.append(str(destination))
 
         self.cli(*args)
 

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import jubilant
 
 from . import mocks
@@ -77,3 +79,10 @@ def test_list_args(run: mocks.Run):
     juju = jubilant.Juju()
 
     juju.deploy('charm', attach_storage=['stg1', 'stg2'], to=['to1', 'to2'])
+
+
+def test_path(run: mocks.Run):
+    run.handle(['juju', 'deploy', 'xyz'])
+    juju = jubilant.Juju()
+
+    juju.deploy(pathlib.Path('xyz'))

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import jubilant
 
 from . import mocks
@@ -61,3 +63,10 @@ def test_all_args(run: mocks.Run):
         storage={'data': 'tmpfs,1G'},
         trust=True,
     )
+
+
+def test_path(run: mocks.Run):
+    run.handle(['juju', 'refresh', 'xyz', '--path', 'foo'])
+    juju = jubilant.Juju()
+
+    juju.refresh('xyz', path=pathlib.Path('foo'))

--- a/tests/unit/test_scp.py
+++ b/tests/unit/test_scp.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import jubilant
 
 from . import mocks
@@ -28,3 +30,17 @@ def test_all_args(run: mocks.Run):
     juju = jubilant.Juju()
 
     juju.scp('SRC', 'DST', container='redis', host_key_checks=False, scp_options=['-r', '-C'])
+
+
+def test_path_source(run: mocks.Run):
+    run.handle(['juju', 'scp', '--', 'SRC', 'DST'])
+    juju = jubilant.Juju()
+
+    juju.scp(pathlib.Path('SRC'), 'DST')
+
+
+def test_path_destination(run: mocks.Run):
+    run.handle(['juju', 'scp', '--', 'SRC', 'DST'])
+    juju = jubilant.Juju()
+
+    juju.scp('SRC', pathlib.Path('DST'))

--- a/tests/unit/test_scp.py
+++ b/tests/unit/test_scp.py
@@ -1,0 +1,17 @@
+import jubilant
+
+from . import mocks
+
+
+def test_minimal(run: mocks.Run):
+    run.handle(['juju', 'scp', '--', 'SRC', 'DST'])
+    juju = jubilant.Juju()
+
+    juju.scp('SRC', 'DST')
+
+
+def test_all_args(run: mocks.Run):
+    run.handle(['juju', 'scp', '--container', 'redis', '--no-host-key-checks', '--', '-r', '-C', 'SRC', 'DST'])
+    juju = jubilant.Juju()
+
+    juju.scp('SRC', 'DST', container='redis', host_key_checks=False, scp_options=['-r', '-C'])

--- a/tests/unit/test_scp.py
+++ b/tests/unit/test_scp.py
@@ -11,7 +11,20 @@ def test_minimal(run: mocks.Run):
 
 
 def test_all_args(run: mocks.Run):
-    run.handle(['juju', 'scp', '--container', 'redis', '--no-host-key-checks', '--', '-r', '-C', 'SRC', 'DST'])
+    run.handle(
+        [
+            'juju',
+            'scp',
+            '--container',
+            'redis',
+            '--no-host-key-checks',
+            '--',
+            '-r',
+            '-C',
+            'SRC',
+            'DST',
+        ]
+    )
     juju = jubilant.Juju()
 
     juju.scp('SRC', 'DST', container='redis', host_key_checks=False, scp_options=['-r', '-C'])


### PR DESCRIPTION
This PR adds `Juju.scp`, as follows:

```python
    def scp(
        self,
        source: str,
        destination: str,
        *,
        container: str | None = None,
        host_key_checks: bool = True,
        scp_options: Iterable[str] = (),
    ) -> None:
```

It's roughly consistent with the existing `ssh` command, though that separates `user` into a separate argument (whereas here `source` and `destination` may have different users, so I don't think it's worth doing that).

Fixes #94