### PR TITLE
fix: log wait status diffs under jubilant.wait logger name

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -17,6 +17,7 @@ from ._task import Task
 from .statustypes import Status
 
 logger = logging.getLogger('jubilant')
+logger_wait = logging.getLogger('jubilant.wait')
 
 
 class CLIError(subprocess.CalledProcessError):
@@ -832,7 +833,7 @@ class Juju:
             if status != prev_status:
                 diff = _status_diff(prev_status, status)
                 if diff:
-                    logger.info('wait: status changed:\n%s', diff)
+                    logger_wait.info('wait: status changed:\n%s', diff)
 
             if error is not None and error(status):
                 raise WaitError(f'error function {error.__qualname__} returned false\n{status}')

--- a/tests/unit/test_wait.py
+++ b/tests/unit/test_wait.py
@@ -22,7 +22,7 @@ def test_ready_normal(run: mocks.Run, time: mocks.Time):
 def test_logging(run: mocks.Run, time: mocks.Time, caplog: pytest.LogCaptureFixture):
     run.handle(['juju', 'status', '--format', 'json'], stdout=MINIMAL_JSON)
     juju = jubilant.Juju()
-    caplog.set_level(logging.INFO, logger='jubilant')
+    caplog.set_level(logging.INFO, logger='jubilant.wait')
 
     juju.wait(lambda _: True)
 


### PR DESCRIPTION
This changes the `Juju.wait` "status diff logs" to log under a separate `jubilant.wait` logger, rather than the top-level `jubilant` logger, so that it's easier for users to control them or turn them off separately.

Fixes #104.