### PR TITLE
feat: add add_secret method

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -127,6 +127,36 @@ class Juju:
         self.cli(*args, include_model=False)
         self.model = model
 
+    def add_secret(
+        self,
+        name: str,
+        content: Mapping[str, str],
+        *,
+        info: str | None = None,
+    ) -> SecretURI:
+        """Add a new named secret and returns its secret URI.
+
+        Args:
+            name: Name for the secret.
+            content: Key-value pairs that represent the secret content, for example
+                ``{'password': 'hunter2'}``.
+            info: Optional description for the secret.
+        """
+        args = ['add-secret', name]
+        if info is not None:
+            args.extend(['--info', info])
+
+        with tempfile.NamedTemporaryFile('w+', delete=False, dir=self._temp_dir) as file:
+            _yaml.safe_dump(content, file)
+            args.extend(['--file', file.name])
+
+        try:
+            output = self.cli(*args)
+        finally:
+            os.remove(file.name)
+
+        return SecretURI(output.strip())
+
     def add_unit(
         self,
         app: str,

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -44,12 +44,11 @@ def test_add_secret(juju: jubilant.Juju):
     uri = juju.add_secret(
         'sec1', {'username': 'usr', 'password': 'hunter2'}, info='A description.'
     )
+    assert uri.startswith('secret:')
 
-    id = str(uri[len('secret:') :] if uri.startswith('secret:') else uri)
     output = juju.cli('show-secret', 'sec1', '--reveal', '--format', 'json')
     result = json.loads(output)
-    secret = result[id]
-
+    secret = result[uri[len('secret:'):]]
     assert secret['name'] == 'sec1'
     assert secret['description'] == 'A description.'
     assert secret['content']['Data'] == {'username': 'usr', 'password': 'hunter2'}

--- a/tests/unit/test_add_secret.py
+++ b/tests/unit/test_add_secret.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os.path
+import subprocess
+from typing import Any
+
+import pytest
+import yaml
+
+import jubilant
+
+
+def test_normal(monkeypatch: pytest.MonkeyPatch):
+    path = ''
+
+    def mock_run(args: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal path
+        assert args[:-1] == [
+            'juju',
+            'add-secret',
+            'sec1',
+            '--info',
+            'A description.',
+            '--file',
+        ]
+        (path,) = args[-1:]  # Ensure there's no extra args
+        with open(path) as f:
+            params = yaml.safe_load(f)
+        assert params == {'username': 'usr', 'password': 'hunter2'}
+        return subprocess.CompletedProcess(
+            args=args, returncode=0, stdout='secret:0123456789abcdefghji\n'
+        )
+
+    monkeypatch.setattr('subprocess.run', mock_run)
+    juju = jubilant.Juju()
+
+    secret_uri = juju.add_secret(
+        'sec1', {'username': 'usr', 'password': 'hunter2'}, info='A description.'
+    )
+
+    assert isinstance(secret_uri, jubilant.SecretURI)
+    assert secret_uri == 'secret:0123456789abcdefghji'  # noqa: S105
+    assert path
+    assert not os.path.exists(path)


### PR DESCRIPTION
This PR adds support for the `juju add-secret` command to add a new named ("user") secret. It sets the secret content using a temporary file (like `run` with parameters) to avoid putting sensitive data on the command line.

Fixes #4