### PR TITLE
feat: add model-config command

### DIFF
--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -325,7 +325,7 @@ juju.cli(
 
 ### A `fast_forward` context manager
 
-Pytest-operator has a `fast_forward` context manager which temporarily speeds up `update-status` hooks to fire every 10 seconds (instead of Juju's default of every 5 minutes). Jubilant doesn't provide this context manager, as we don't recommend it for new tests, but if you need it for migrating existing tests, you can define it as:
+Pytest-operator has a `fast_forward` context manager which temporarily speeds up `update-status` hooks to fire every 10 seconds (instead of Juju's default of every 5 minutes). Jubilant doesn't provide this context manager, as we don't recommend it for new tests. If you need it for migrating existing tests, you can define it as:
 
 ```python
 @contextlib.contextmanager

--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -323,6 +323,22 @@ juju.cli(
 )
 ```
 
+### A `fast_forward` context manager
+
+Pytest-operator has a `fast_forward` context manager which temporarily speeds up `update-status` hooks to fire every 10 seconds (instead of Juju's default of every 5 minutes). Jubilant doesn't provide this context manager, as we don't recommend it for new tests, but if you need it for migrating existing tests, you can define it as:
+
+```python
+@contextlib.contextmanager
+def fast_forward(juju: jubilant.Juju):
+    """Context manager that temporarily speeds up update-status hooks to fire every 10s."""
+    old = juju.model_config()['update-status-hook-interval']
+    juju.model_config({'update-status-hook-interval': '10s'})
+    try:
+        yield
+    finally:
+        juju.model_config({'update-status-hook-interval': old})
+```
+
 
 ## See more
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -210,13 +210,13 @@ class Juju:
         """Get or set the configuration of a deployed application.
 
         If called with only the *app* argument, get the config and return it.
-        If called with the *values* argument, set the config values and return
-        ``None``.
+
+        If called with the *values* argument, set the config values and return None.
+        For values in *values* that are None, reset them to their defaults.
 
         Args:
             app: Application name to get or set config for.
-            values: Mapping of config names to values to set. Reset values that are
-                ``None``.
+            values: Mapping of config names to values to set. Reset values that are None.
             app_config: When getting config, set this to True to get the
                 (poorly-named) "application-config" values instead of charm config.
         """
@@ -482,11 +482,13 @@ class Juju:
         """Get or set the configuration of the model.
 
         If called with no arguments, get the model config and return it.
-        If called with the *values* argument, set the model config values and return ``None``.
+
+        If called with the *values* argument, set the model config values and return None.
+        For values in *values* that are None, reset them to their defaults.
 
         Args:
             values: Mapping of model config names to values to set, for example
-                ``{'update-status-hook-interval': '10s'}``. Reset values that are ``None``.
+                ``{'update-status-hook-interval': '10s'}``. Reset values that are None.
         """
         if values is None:
             stdout = self.cli('model-config', '--format', 'json')

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -87,9 +87,9 @@ def test_set(run: mocks.Run):
 
 
 def test_set_with_model(run: mocks.Run):
-    run.handle(['juju', 'config', 'app2', 'foo=bar'])
+    run.handle(['juju', 'config', '--model', 'mdl', 'app2', 'foo=bar'])
 
-    juju = jubilant.Juju()
+    juju = jubilant.Juju(model='mdl')
     retval = juju.config('app2', {'foo': 'bar'})
     assert retval is None
 

--- a/tests/unit/test_model_config.py
+++ b/tests/unit/test_model_config.py
@@ -1,0 +1,85 @@
+import jubilant
+
+from . import mocks
+
+CONFIG_JSON = """
+{
+    "booly": {"Value": true, "type": "boolean"},
+    "inty": {"Value": 42, "type": "int"},
+    "floaty": {"Value": 7.5, "type": "float"},
+    "stry": {"Value": "A string.", "type": "string"}
+}
+"""
+
+
+def test_get(run: mocks.Run):
+    run.handle(['juju', 'model-config', '--format', 'json'], stdout=CONFIG_JSON)
+
+    juju = jubilant.Juju()
+    values = juju.model_config()
+    assert values == {
+        'booly': True,
+        'inty': 42,
+        'floaty': 7.5,
+        'stry': 'A string.',
+    }
+
+
+def test_get_with_model(run: mocks.Run):
+    run.handle(['juju', 'model-config', '--model', 'mdl', '--format', 'json'], stdout=CONFIG_JSON)
+
+    juju = jubilant.Juju(model='mdl')
+    values = juju.model_config()
+    assert values == {
+        'booly': True,
+        'inty': 42,
+        'floaty': 7.5,
+        'stry': 'A string.',
+    }
+
+
+def test_set(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'model-config',
+            'booly=true',
+            'inty=42',
+            'floaty=7.5',
+            'stry=A string.',
+        ]
+    )
+
+    juju = jubilant.Juju()
+    values = {
+        'booly': True,
+        'inty': 42,
+        'floaty': 7.5,
+        'stry': 'A string.',
+    }
+    retval = juju.model_config(values)
+    assert retval is None
+
+
+def test_set_with_model(run: mocks.Run):
+    run.handle(['juju', 'model-config', '--model', 'mdl', 'foo=bar'])
+
+    juju = jubilant.Juju(model='mdl')
+    retval = juju.model_config({'foo': 'bar'})
+    assert retval is None
+
+
+def test_reset(run: mocks.Run):
+    run.handle(['juju', 'model-config', '--reset', 'x,why,zed'])
+
+    juju = jubilant.Juju()
+    retval = juju.model_config({'x': None, 'why': None, 'zed': None})
+    assert retval is None
+
+
+def test_set_with_reset(run: mocks.Run):
+    run.handle(['juju', 'model-config', 'foo=bar', '--reset', 'baz,buzz'])
+
+    juju = jubilant.Juju()
+    retval = juju.model_config({'foo': 'bar', 'baz': None, 'buzz': None})
+    assert retval is None


### PR DESCRIPTION
This adds support for `juju model-config`: `Juju.model_config`, very similar to the existing `Juju.config` method. I've also added an example of an ops_test-like `fast_forward` context manager.

I don't want to add `fast_forward`, as I don't like it as a practice. I also don't like the name, and it seems too specific. I would consider adding a more general context manager like `jubilant.temp_model_config`, but I think it's better at least for now to leave it to the charms.

Fixes #106.