### PR TITLE
fix!: change all_* and any_* to take *apps instead of a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ juju.deploy('snappass-test')
 juju.wait(jubilant.all_active)
 
 # Or only wait for specific applications:
-juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
+juju.wait(lambda status: jubilant.all_active(status, 'snappass-test', 'another-app'))
 ```
 
 Below is an example of a charm integration test. First we define a module-scoped [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) named `juju` which creates a temporary model and runs the test with a `Juju` instance pointing at that model. Jubilant's`temp_model` context manager creates the model during test setup and destroys it during teardown:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ import jubilant
 juju = jubilant.Juju()
 juju.deploy('snappass-test')
 juju.wait(jubilant.all_active)
+
+# Or specify application names more specifically:
+juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
 ```
 
 Below is an example of a charm integration test. First we define a module-scoped [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) named `juju` which creates a temporary model and runs the test with a `Juju` instance pointing at that model. Jubilant's`temp_model` context manager creates the model during test setup and destroys it during teardown:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ juju = jubilant.Juju()
 juju.deploy('snappass-test')
 juju.wait(jubilant.all_active)
 
-# Or specify application names more specifically:
+# Or only wait for specific applications:
 juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
 ```
 

--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -82,7 +82,7 @@ def test_active(juju: jubilant.Juju):
     juju.deploy('mycharm')
     juju.wait(jubilant.all_active)
 
-    # Or wait for just 'mycharm' to be active (ignore other apps):
+    # Or wait for just 'mycharm' to be active (ignoring other apps):
     juju.wait(lambda status: jubilant.all_active(status, 'mycharm'))
 ```
 
@@ -228,10 +228,15 @@ def test_active(juju: jubilant.Juju):
     juju.wait(jubilant.all_active, error=jubilant.any_error)
 ```
 
-It's common to use a `lambda` function to customize the callables further. For example, to wait specifically for `mysql` and `redis` to go active:
+It's common to use a `lambda` function to customize the callable or compose multiple checks. For example, to wait specifically for `mysql` and `redis` to go active and `logger` to be blocked:
 
 ```python
-juju.wait(lambda status: jubilant.all_active(status, 'mysql', 'redis'))
+juju.wait(
+    lambda status: (
+        jubilant.all_active(status, 'mysql', 'redis') and
+        jubilant.all_blocked(status, 'logger'),
+    ),
+)
 ```
 
 The `wait` method also has other options (see [`juju.wait`](jubilant.Juju.wait) for details):

--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -81,6 +81,9 @@ In your tests, use the fixture like this:
 def test_active(juju: jubilant.Juju):
     juju.deploy('mycharm')
     juju.wait(jubilant.all_active)
+
+    # Or wait more specifically for only 'mycharm' to be active:
+    juju.wait(lambda status: jubilant.all_active(status, 'mycharm'))
 ```
 
 A few things to note about the fixture:
@@ -183,7 +186,7 @@ juju.deploy(
     trust=True,
     config={'profile': 'testing'},
 )
-juju.wait(lambda status: status.apps['postgresql-k8s'].is_active)
+juju.wait(lambda status: jubilant.all_active(status, 'postgresql-k8s'))
 ```
 
 ### Fetching status
@@ -228,7 +231,7 @@ def test_active(juju: jubilant.Juju):
 It's common to use a `lambda` function to customize the callables further. For example, to wait specifically for `mysql` and `redis` to go active:
 
 ```python
-juju.wait(lambda status: jubilant.all_active(status, ['mysql', 'redis']))
+juju.wait(lambda status: jubilant.all_active(status, 'mysql', 'redis'))
 ```
 
 The `wait` method also has other options (see [`juju.wait`](jubilant.Juju.wait) for details):
@@ -236,7 +239,7 @@ The `wait` method also has other options (see [`juju.wait`](jubilant.Juju.wait) 
 ```python
 juju.deploy('mycharm')
 juju.wait(
-    ready=lambda status: status.apps['mycharm'].is_active,
+    ready=lambda status: jubilant.all_active(status, 'mycharm'),
     error=jubilant.any_error,
     delay=0.2,    # poll "juju status" every 200ms (default 1s)
     timeout=60,   # set overall timeout to 60s (default juju.wait_timeout)

--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -82,7 +82,7 @@ def test_active(juju: jubilant.Juju):
     juju.deploy('mycharm')
     juju.wait(jubilant.all_active)
 
-    # Or wait more specifically for only 'mycharm' to be active:
+    # Or wait for just 'mycharm' to be active (ignore other apps):
     juju.wait(lambda status: jubilant.all_active(status, 'mycharm'))
 ```
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -76,8 +76,10 @@ Integration tests in a test file would use the fixture, operating on the tempora
 ```python
 def test_deploy(juju: jubilant.Juju):
     juju.deploy('snappass-test')
-    status = juju.wait(jubilant.all_active)
-    assert status.apps['snappass-test'].scale == 1
+    juju.wait(jubilant.all_active)
+
+    # Or wait more specifically for only 'snappass-test' to be active:
+    juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
 ```
 
 You may want to adjust the [scope](https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes) of your `juju` fixture. For example, to create a new model for every test function (pytest's default behavior), omit the scope:
@@ -93,9 +95,20 @@ def juju():
 
 When waiting on a condition with [`Juju.wait`](jubilant.Juju.wait), you can use pre-defined helpers including [](jubilant.all_active) and [](jubilant.any_error). You can also define custom conditions for the *ready* and *error* parameters. This is typically done with inline `lambda` functions.
 
-For example, to test that the `myapp` charm starts up with application status "unknown":
+For example, to deploy and wait till all the specified applications (`blog`, `mysql`, and `redis`) are "active":
 
+```python
+def test_active_apps(juju: jubilant.Juju):
+    for app in ['blog', 'mysql', 'redis']:
+        juju.deploy(app)
+    juju.integrate('blog', 'mysql')
+    juju.integrate('blog', 'redis')
+    juju.wait(lambda status: jubilant.all_active(status, 'blog', 'mysql', 'redis'))
 ```
+
+Or to test that the `myapp` charm starts up with application status "unknown":
+
+```python
 def test_unknown(juju: jubilant.Juju):
     juju.deploy('myapp')
     juju.wait(
@@ -107,7 +120,7 @@ There are also `is_*` properties on the [`AppStatus`](jubilant.statustypes.AppSt
 
 For example, to wait till `myapp` is active and `yourapp` is blocked, and to raise an error if any app or unit goes into error state:
 
-```
+```python
 def test_custom_wait(juju: jubilant.Juju):
     juju.deploy('myapp')
     juju.deploy('yourapp')

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -78,7 +78,7 @@ def test_deploy(juju: jubilant.Juju):
     juju.deploy('snappass-test')
     juju.wait(jubilant.all_active)
 
-    # Or wait more specifically for only 'snappass-test' to be active:
+    # Or wait for just 'snappass-test' to be active (ignore other apps):
     juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
 ```
 
@@ -103,7 +103,9 @@ def test_active_apps(juju: jubilant.Juju):
         juju.deploy(app)
     juju.integrate('blog', 'mysql')
     juju.integrate('blog', 'redis')
-    juju.wait(lambda status: jubilant.all_active(status, 'blog', 'mysql', 'redis'))
+    juju.wait(
+        lambda status: jubilant.all_active(status, 'blog', 'mysql', 'redis'),
+    )
 ```
 
 Or to test that the `myapp` charm starts up with application status "unknown":
@@ -116,7 +118,7 @@ def test_unknown(juju: jubilant.Juju):
     )
 ```
 
-There are also `is_*` properties on the [`AppStatus`](jubilant.statustypes.AppStatus) and [`UnitStatus`](jubilant.statustypes.UnitStatus) classes for the common statuses: `is_active`, `is_blocked`, `is_error`, `is_maintenance`, and `is_waiting`.
+There are also `is_*` properties on the [`AppStatus`](jubilant.statustypes.AppStatus) and [`UnitStatus`](jubilant.statustypes.UnitStatus) classes for the common statuses: `is_active`, `is_blocked`, `is_error`, `is_maintenance`, and `is_waiting`. These test the status of a single application or unit, whereas the `jubilant.all_*` and `jubilant.any_*` functions test the statuses of multiple applications *and* all their units.
 
 For example, to wait till `myapp` is active and `yourapp` is blocked, and to raise an error if any app or unit goes into error state:
 

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -78,7 +78,7 @@ def test_deploy(juju: jubilant.Juju):
     juju.deploy('snappass-test')
     juju.wait(jubilant.all_active)
 
-    # Or wait for just 'snappass-test' to be active (ignore other apps):
+    # Or wait for just 'snappass-test' to be active (ignoring other apps):
     juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
 ```
 

--- a/jubilant/_all_any.py
+++ b/jubilant/_all_any.py
@@ -19,7 +19,7 @@ def all_active(status: Status, *apps: str) -> bool:
     Args:
         status: The status object being tested.
         apps: An optional list of application names. If provided, only these applications
-            (and their units) are tested.
+            (and their units) are tested, and each must be present in ``status.apps``.
     """
     return _all_statuses_are('active', status, apps)
 
@@ -32,7 +32,7 @@ def all_blocked(status: Status, *apps: str) -> bool:
     Args:
         status: The status object being tested.
         apps: An optional list of application names. If provided, only these applications
-            (and their units) are tested.
+            (and their units) are tested, and each must be present in ``status.apps``.
     """
     return _all_statuses_are('blocked', status, apps)
 
@@ -45,7 +45,7 @@ def all_error(status: Status, *apps: str) -> bool:
     Args:
         status: The status object being tested.
         apps: An optional list of application names. If provided, only these applications
-            (and their units) are tested.
+            (and their units) are tested, and each must be present in ``status.apps``.
     """
     return _all_statuses_are('error', status, apps)
 
@@ -58,7 +58,7 @@ def all_maintenance(status: Status, *apps: str) -> bool:
     Args:
         status: The status object being tested.
         apps: An optional list of application names. If provided, only these applications
-            (and their units) are tested.
+            (and their units) are tested, and each must be present in ``status.apps``.
     """
     return _all_statuses_are('maintenance', status, apps)
 
@@ -71,7 +71,7 @@ def all_waiting(status: Status, *apps: str) -> bool:
     Args:
         status: The status object being tested.
         apps: An optional list of application names. If provided, only these applications
-            (and their units) are tested.
+            (and their units) are tested, and each must be present in ``status.apps``.
     """
     return _all_statuses_are('waiting', status, apps)
 

--- a/jubilant/_all_any.py
+++ b/jubilant/_all_any.py
@@ -5,8 +5,16 @@ from collections.abc import Iterable
 from .statustypes import Status
 
 
-def all_active(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether all applications and units in *status* are in "active" status.
+def all_active(status: Status, *apps: str) -> bool:
+    """Report whether all apps and units in *status* (or in *apps* if provided) are "active".
+
+    Examples::
+
+        # Use the callable directly to wait for all apps in status to be active.
+        juju.wait(jubilant.all_active)
+
+        # Use a lambda to wait for all apps specified (blog, mysql) to be active.
+        juju.wait(lambda status: jubilant.all_active(status, 'blog', 'mysql'))
 
     Args:
         status: The status object being tested.
@@ -16,8 +24,10 @@ def all_active(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _all_statuses_are('active', status, apps)
 
 
-def all_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether all applications and units in *status* are in "blocked" status.
+def all_blocked(status: Status, *apps: str) -> bool:
+    """Report whether all apps and units in *status* (or in *apps* if provided) are "blocked".
+
+    See :func:`all_active` for examples.
 
     Args:
         status: The status object being tested.
@@ -27,8 +37,10 @@ def all_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _all_statuses_are('blocked', status, apps)
 
 
-def all_error(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether all applications and units in *status* are in "error" status.
+def all_error(status: Status, *apps: str) -> bool:
+    """Report whether all apps and units in *status* (or in *apps* if provided) are "error".
+
+    See :func:`all_active` for examples.
 
     Args:
         status: The status object being tested.
@@ -38,8 +50,10 @@ def all_error(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _all_statuses_are('error', status, apps)
 
 
-def all_maintenance(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether all applications and units in *status* are in "maintenance" status.
+def all_maintenance(status: Status, *apps: str) -> bool:
+    """Report whether all apps and units in *status* (or in *apps* if provided) are "maintenance".
+
+    See :func:`all_active` for examples.
 
     Args:
         status: The status object being tested.
@@ -49,8 +63,10 @@ def all_maintenance(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _all_statuses_are('maintenance', status, apps)
 
 
-def all_waiting(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether all applications and units in *status* are in "waiting" status.
+def all_waiting(status: Status, *apps: str) -> bool:
+    """Report whether all apps and units in *status* (or in *apps* if provided) are "waiting".
+
+    See :func:`all_active` for examples.
 
     Args:
         status: The status object being tested.
@@ -60,8 +76,10 @@ def all_waiting(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _all_statuses_are('waiting', status, apps)
 
 
-def any_active(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether any application or unit in *status* is in "active" status.
+def any_active(status: Status, *apps: str) -> bool:
+    """Report whether any app or unit in *status* (or in *apps* if provided) is "active".
+
+    See :func:`any_error` for examples.
 
     Args:
         status: The status object being tested.
@@ -71,8 +89,10 @@ def any_active(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _any_status_is('active', status, apps)
 
 
-def any_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether any application or unit in *status* is in "blocked" status.
+def any_blocked(status: Status, *apps: str) -> bool:
+    """Report whether any app or unit in *status* (or in *apps* if provided) is "blocked".
+
+    See :func:`any_error` for examples.
 
     Args:
         status: The status object being tested.
@@ -82,8 +102,19 @@ def any_blocked(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _any_status_is('blocked', status, apps)
 
 
-def any_error(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether any application or unit in *status* is in "error" status.
+def any_error(status: Status, *apps: str) -> bool:
+    """Report whether any app or unit in *status* (or in *apps* if provided) is "error".
+
+    Examples::
+
+        # Use the callable directly to raise an error if any apps go into error.
+        juju.wait(jubilant.all_active, error=jubilant.any_error)
+
+        # Use a lambda to wait for any of the apps specified (blog, mysql) to go into error.
+        juju.wait(
+            jubilant.all_active,
+            error=lambda status: jubilant.any_error(status, 'blog', 'mysql')),
+        )
 
     Args:
         status: The status object being tested.
@@ -93,8 +124,10 @@ def any_error(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _any_status_is('error', status, apps)
 
 
-def any_maintenance(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether any application or unit in *status* is in "maintenance" status.
+def any_maintenance(status: Status, *apps: str) -> bool:
+    """Report whether any app or unit in *status* (or in *apps* if provided) is "maintenance".
+
+    See :func:`any_error` for examples.
 
     Args:
         status: The status object being tested.
@@ -104,8 +137,10 @@ def any_maintenance(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _any_status_is('maintenance', status, apps)
 
 
-def any_waiting(status: Status, apps: Iterable[str] | None = None) -> bool:
-    """Report whether any application or unit in *status* is in "waiting" status.
+def any_waiting(status: Status, *apps: str) -> bool:
+    """Report whether any app or unit in *status* (or in *apps* if provided) is "waiting".
+
+    See :func:`any_error` for examples.
 
     Args:
         status: The status object being tested.
@@ -115,11 +150,8 @@ def any_waiting(status: Status, apps: Iterable[str] | None = None) -> bool:
     return _any_status_is('waiting', status, apps)
 
 
-def _all_statuses_are(expected: str, status: Status, apps: Iterable[str] | None) -> bool:
-    if isinstance(apps, (str, bytes)):
-        raise TypeError('"apps" must be an iterable of names (like a list), not a string')
-
-    if apps is None:
+def _all_statuses_are(expected: str, status: Status, apps: Iterable[str]) -> bool:
+    if not apps:
         apps = status.apps.keys()
 
     for app in apps:
@@ -134,11 +166,8 @@ def _all_statuses_are(expected: str, status: Status, apps: Iterable[str] | None)
     return True
 
 
-def _any_status_is(expected: str, status: Status, apps: Iterable[str] | None) -> bool:
-    if isinstance(apps, (str, bytes)):
-        raise TypeError('"apps" must be an iterable of names (like a list), not a string')
-
-    if apps is None:
+def _any_status_is(expected: str, status: Status, apps: Iterable[str]) -> bool:
+    if not apps:
         apps = status.apps.keys()
 
     for app in apps:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -907,7 +907,8 @@ class Juju:
             juju.deploy('snappass-test')
             juju.wait(jubilant.all_active)
 
-            # Or wait specifically for 'snappass-test' to be active, and raise on any error.
+            # Or something more complex: wait specifically for 'snappass-test' to be active,
+            # and raise if any app or unit is seen in "error" status while waiting.
             juju.wait(
                 lambda status: jubilant.all_active(status, 'snappass-test'),
                 error=jubilant.any_error,

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -48,8 +48,10 @@ class SecretURI(str):
         for example "9m4e2mr0ui3e8a215n4g").
         """
         if '/' in self:
+            # Handle 'secret://MODEL-UUID/UNIQUE-IDENTIFIER'
             return self.rsplit('/', maxsplit=1)[-1]
         elif self.startswith('secret:'):
+            # Handle common case of 'secret:UNIQUE-IDENTIFIER'
             return self[len('secret:') :]
         else:
             return str(self)

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -825,8 +825,11 @@ class Juju:
 
             juju = jubilant.Juju()
             juju.deploy('snappass-test')
+            juju.wait(jubilant.all_active)
+
+            # Or wait specifically for 'snappass-test' to be active, and raise on any error.
             juju.wait(
-                lambda status: status.apps['snappass-test'].is_active,
+                lambda status: jubilant.all_active(status, 'snappass-test'),
                 error=jubilant.any_error,
             )
 

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -104,7 +104,7 @@ def test_exec_error_machine_on_k8s(juju: jubilant.Juju):
 def test_ssh_and_scp(juju: jubilant.Juju):
     # The 'testdb' charm doesn't have any containers, so use 'snappass-test'.
     juju.deploy('snappass-test')
-    juju.wait(lambda status: jubilant.all_active(status, ['snappass-test']))
+    juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
 
     output = juju.ssh('snappass-test/0', 'ls', '/charm/containers')
     assert output.split() == ['redis', 'snappass']

--- a/tests/unit/test_all_any.py
+++ b/tests/unit/test_all_any.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Any
+from typing import Any, Protocol
 
 import pytest
 
 import jubilant
 
 from .fake_statuses import MINIMAL_STATUS, SNAPPASS_JSON
+
+
+class AllAnyFunc(Protocol):
+    def __call__(self, status: jubilant.Status, *apps: str) -> bool: ...
 
 
 @pytest.mark.parametrize(
@@ -21,10 +25,9 @@ from .fake_statuses import MINIMAL_STATUS, SNAPPASS_JSON
         jubilant.all_waiting,
     ],
 )
-def test_all_no_apps(all_func: Any):
+def test_all_no_apps(all_func: AllAnyFunc):
     # Just like Python's all(), all_* helpers return True if no apps
     assert all_func(MINIMAL_STATUS)
-    assert all_func(MINIMAL_STATUS, [])
 
 
 @pytest.mark.parametrize(
@@ -37,10 +40,9 @@ def test_all_no_apps(all_func: Any):
         jubilant.any_waiting,
     ],
 )
-def test_any_no_apps(any_func: Any):
+def test_any_no_apps(any_func: AllAnyFunc):
     # Just like Python's any(), any_* helpers return False if no apps
     assert not any_func(MINIMAL_STATUS)
-    assert not any_func(MINIMAL_STATUS, [])
 
 
 @pytest.mark.parametrize(
@@ -53,14 +55,14 @@ def test_any_no_apps(any_func: Any):
         (jubilant.all_waiting, 'waiting', 'error'),
     ],
 )
-def test_all_one_app(all_func: Any, expected: str, unexpected: str):
+def test_all_one_app(all_func: AllAnyFunc, expected: str, unexpected: str):
     status_dict = json.loads(SNAPPASS_JSON)
     set_app_and_unit_status(status_dict, 'snappass-test', expected, expected)
     status = jubilant.Status._from_dict(status_dict)
     assert all_func(status)
-    assert all_func(status, ['snappass-test'])
-    assert not all_func(status, ['other'])
-    assert not all_func(status, ['snappass-test', 'other'])
+    assert all_func(status, 'snappass-test')
+    assert not all_func(status, 'other')
+    assert not all_func(status, 'snappass-test', 'other')
 
     # Should return False if app status is not the expected status
     set_app_and_unit_status(status_dict, 'snappass-test', unexpected, expected)
@@ -83,14 +85,14 @@ def test_all_one_app(all_func: Any, expected: str, unexpected: str):
         (jubilant.any_waiting, 'waiting', 'error'),
     ],
 )
-def test_any_one_app(any_func: Any, expected: str, unexpected: str):
+def test_any_one_app(any_func: AllAnyFunc, expected: str, unexpected: str):
     status_dict = json.loads(SNAPPASS_JSON)
     set_app_and_unit_status(status_dict, 'snappass-test', expected, expected)
     status = jubilant.Status._from_dict(status_dict)
     assert any_func(status)
-    assert any_func(status, ['snappass-test'])
-    assert not any_func(status, ['other'])
-    assert any_func(status, ['snappass-test', 'other'])
+    assert any_func(status, 'snappass-test')
+    assert not any_func(status, 'other')
+    assert any_func(status, 'snappass-test', 'other')
 
     # Should return True if app status is not the expected status but unit status is
     set_app_and_unit_status(status_dict, 'snappass-test', unexpected, expected)
@@ -113,17 +115,17 @@ def test_any_one_app(any_func: Any, expected: str, unexpected: str):
         (jubilant.all_waiting, 'waiting', 'error'),
     ],
 )
-def test_all_two_apps(all_func: Any, expected: str, unexpected: str):
+def test_all_two_apps(all_func: AllAnyFunc, expected: str, unexpected: str):
     status_dict = json.loads(SNAPPASS_JSON)
     set_app_and_unit_status(status_dict, 'snappass-test', expected, expected)
     add_app(status_dict, 'snappass-test', 'app2')
     status = jubilant.Status._from_dict(status_dict)
     assert all_func(status)
-    assert all_func(status, ['snappass-test'])
-    assert all_func(status, ['snappass-test', 'app2'])
-    assert not all_func(status, ['snappass-test', 'other'])
-    assert not all_func(status, ['snappass-test', 'app2', 'other'])
-    assert not all_func(status, ['other1', 'other2'])
+    assert all_func(status, 'snappass-test')
+    assert all_func(status, 'snappass-test', 'app2')
+    assert not all_func(status, 'snappass-test', 'other')
+    assert not all_func(status, 'snappass-test', 'app2', 'other')
+    assert not all_func(status, 'other1', 'other2')
 
     # Should return False if one app is the expected status but the other is not
     set_app_and_unit_status(status_dict, 'snappass-test', unexpected, expected)
@@ -146,17 +148,17 @@ def test_all_two_apps(all_func: Any, expected: str, unexpected: str):
         (jubilant.any_waiting, 'waiting', 'error'),
     ],
 )
-def test_any_two_apps(any_func: Any, expected: str, unexpected: str):
+def test_any_two_apps(any_func: AllAnyFunc, expected: str, unexpected: str):
     status_dict = json.loads(SNAPPASS_JSON)
     set_app_and_unit_status(status_dict, 'snappass-test', expected, expected)
     add_app(status_dict, 'snappass-test', 'app2')
     status = jubilant.Status._from_dict(status_dict)
     assert any_func(status)
-    assert any_func(status, ['snappass-test'])
-    assert any_func(status, ['snappass-test', 'app2'])
-    assert any_func(status, ['snappass-test', 'other'])
-    assert any_func(status, ['snappass-test', 'app2', 'other'])
-    assert not any_func(status, ['other1', 'other2'])
+    assert any_func(status, 'snappass-test')
+    assert any_func(status, 'snappass-test', 'app2')
+    assert any_func(status, 'snappass-test', 'other')
+    assert any_func(status, 'snappass-test', 'app2', 'other')
+    assert not any_func(status, 'other1', 'other2')
 
     # Should return True if one app is the expected status but the other is not
     set_app_and_unit_status(status_dict, 'snappass-test', unexpected, unexpected)
@@ -167,28 +169,6 @@ def test_any_two_apps(any_func: Any, expected: str, unexpected: str):
     set_app_and_unit_status(status_dict, 'app2', unexpected, unexpected)
     status = jubilant.Status._from_dict(status_dict)
     assert not any_func(status)
-
-
-@pytest.mark.parametrize(
-    'func',
-    [
-        jubilant.all_active,
-        jubilant.all_blocked,
-        jubilant.all_error,
-        jubilant.all_maintenance,
-        jubilant.all_waiting,
-        jubilant.any_active,
-        jubilant.any_blocked,
-        jubilant.any_error,
-        jubilant.any_maintenance,
-        jubilant.any_waiting,
-    ],
-)
-def test_all_and_any_type_errors(func: Any):
-    with pytest.raises(TypeError):
-        func(MINIMAL_STATUS, apps='app')
-    with pytest.raises(TypeError):
-        func(MINIMAL_STATUS, apps=b'app')
 
 
 def set_app_and_unit_status(


### PR DESCRIPTION
This is a breaking change to the signature of the `all_*` and `any_*` functions, per discussion at #114: it changes the usage when apps are specified from `all_active(status, ['app1', 'app2'])` to `all_active(status, 'app1', 'app2')` to simplify and provide better ergonomics.

The PR also adds various examples of `juju.wait` with both the direct-callable and lambda usage to make it clearer how you can use these helpers.

Fixes #114.