### PR TITLE
feat: deploy a temp model into a specified controller

### DIFF
--- a/jubilant/_pretty.py
+++ b/jubilant/_pretty.py
@@ -73,7 +73,7 @@ def dump(value: object, indent: str = '') -> str:
         return repr(value)
 
 
-def gron(value: object, prefix: str = '') -> Generator[str, None, None]:
+def gron(value: object, prefix: str = '') -> Generator[str]:
     """Yield gron-style lines of all fields within value, recursively.
 
     This handles dataclasses, lists, and dicts. It's inspired by gron:
@@ -120,7 +120,7 @@ def gron(value: object, prefix: str = '') -> Generator[str, None, None]:
         yield f'{prefix} = {value!r}'
 
 
-def diff(seq1: Sequence[str], seq2: Sequence[str]) -> Generator[str, None, None]:
+def diff(seq1: Sequence[str], seq2: Sequence[str]) -> Generator[str]:
     """Compare seq1 and seq1; yield lines that have been removed, changed, or added.
 
     Example::

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -1,14 +1,14 @@
+from __future__ import annotations
+
 import contextlib
 import secrets
-from typing import Generator, Union
+from typing import Generator
 
 from ._juju import Juju
 
 
 @contextlib.contextmanager
-def temp_model(
-    keep: bool = False, controller: Union[str, None] = None
-) -> Generator[Juju, None, None]:
+def temp_model(keep: bool = False, controller: str | None = None) -> Generator[Juju]:
     """Context manager to create a temporary model for running tests in.
 
     This creates a new model with a random name in the format ``jubilant-abcd1234``, and destroys
@@ -18,7 +18,7 @@ def temp_model(
 
     Args:
         keep: If true, keep the created model around when the context manager exits.
-        controller: The controller where the temp model will be deployed.
+        controller: Name of controller where the temporary model will be added.
     """
     juju = Juju()
     model = 'jubilant-' + secrets.token_hex(4)  # 4 bytes (8 hex digits) should be plenty

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -26,6 +26,3 @@ def temp_model(keep: bool = False, controller: str | None = None) -> Generator[J
     finally:
         if not keep:
             juju.destroy_model(model, destroy_storage=True, force=True)
-
-
-To test a CMR in an integration test, it would be great to surface the controller option from the add_model method to the temp_model method so I can choose whether to deploy the model to LXD or microk8s.

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -6,7 +6,7 @@ from ._juju import Juju
 
 
 @contextlib.contextmanager
-def temp_model(keep: bool = False) -> Generator[Juju, None, None]:
+def temp_model(keep: bool = False, controller: str | None = None) -> Generator[Juju, None, None]:
     """Context manager to create a temporary model for running tests in.
 
     This creates a new model with a random name in the format ``jubilant-abcd1234``, and destroys
@@ -16,12 +16,16 @@ def temp_model(keep: bool = False) -> Generator[Juju, None, None]:
 
     Args:
         keep: If true, keep the created model around when the context manager exits.
+        controller: The controller where the temp model will be deployed.
     """
     juju = Juju()
     model = 'jubilant-' + secrets.token_hex(4)  # 4 bytes (8 hex digits) should be plenty
-    juju.add_model(model)
+    juju.add_model(model, controller=controller)
     try:
         yield juju
     finally:
         if not keep:
             juju.destroy_model(model, destroy_storage=True, force=True)
+
+
+To test a CMR in an integration test, it would be great to surface the controller option from the add_model method to the temp_model method so I can choose whether to deploy the model to LXD or microk8s.

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -1,12 +1,14 @@
 import contextlib
 import secrets
-from typing import Generator
+from typing import Generator, Union
 
 from ._juju import Juju
 
 
 @contextlib.contextmanager
-def temp_model(keep: bool = False, controller: str | None = None) -> Generator[Juju, None, None]:
+def temp_model(
+    keep: bool = False, controller: Union[str, None] = None
+) -> Generator[Juju, None, None]:
     """Context manager to create a temporary model for running tests in.
 
     This creates a new model with a random name in the format ``jubilant-abcd1234``, and destroys

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,7 +17,7 @@ def pytest_addoption(parser: pytest.OptionGroup):
 
 
 @pytest.fixture(scope='module')
-def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju]:
     """Module-scoped pytest fixture that wraps :meth:`jubilant.with_model`."""
     keep_models = cast(bool, request.config.getoption('--keep-models'))
     with jubilant.temp_model(keep=keep_models) as juju:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,7 +8,7 @@ from . import mocks
 
 
 @pytest.fixture
-def run(monkeypatch: pytest.MonkeyPatch) -> Generator[mocks.Run, None, None]:
+def run(monkeypatch: pytest.MonkeyPatch) -> Generator[mocks.Run]:
     """Pytest fixture that patches subprocess.run with mocks.Run."""
     run_mock = mocks.Run()
     monkeypatch.setattr('subprocess.run', run_mock)
@@ -17,7 +17,7 @@ def run(monkeypatch: pytest.MonkeyPatch) -> Generator[mocks.Run, None, None]:
 
 
 @pytest.fixture
-def time(monkeypatch: pytest.MonkeyPatch) -> Generator[mocks.Time, None, None]:
+def time(monkeypatch: pytest.MonkeyPatch) -> Generator[mocks.Time]:
     """Pytest fixture that patches time.monotonic and time.sleep with mocks.Time."""
     time_mock = mocks.Time()
     monkeypatch.setattr('time.monotonic', time_mock.monotonic)

--- a/tests/unit/test_test_helpers.py
+++ b/tests/unit/test_test_helpers.py
@@ -40,12 +40,12 @@ def test_defaults(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
     assert run.calls[2].args[1] == 'destroy-model'
 
 
-def test_keep(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
+def test_other_args(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr('secrets.token_hex', mock_token_hex)
-    run.handle(['juju', 'add-model', '--no-switch', 'jubilant-abcd1234'])
+    run.handle(['juju', 'add-model', '--no-switch', 'jubilant-abcd1234', '--controller', 'ctrl'])
     run.handle(['juju', 'deploy', '--model', 'jubilant-abcd1234', 'app1'])
 
-    with jubilant.temp_model(keep=True) as juju:
+    with jubilant.temp_model(keep=True, controller='ctrl') as juju:
         assert juju.model == 'jubilant-abcd1234'
         assert len(run.calls) == 1
         assert run.calls[0].args[1] == 'add-model'


### PR DESCRIPTION
To test a CMR in an integration test, it would be great to surface the controller option from the `add_model` method to the `temp_model` method so I can choose whether to deploy the model to LXD or microk8s.

I could manage this manually with juju.add_model, but then I lose the benefit of the automatic teardown.