### PR TITLE
fix!: in "offer", move endpoint to keyword-only arg instead of *args

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -559,25 +559,22 @@ class Juju:
 
         self.cli(*args)
 
-    def offer(self, app: str, *endpoint: str, name: str | None = None) -> None:
+    def offer(self, app: str, *, endpoint: str | Iterable[str], name: str | None = None) -> None:
         """Offer application endpoints for use in other models.
 
         Examples::
 
-            juju.offer('mysql', 'db')
-            juju.offer('mymodel.mysql', 'db', 'log', name='altname')
+            juju.offer('mysql', endpoint='db')
+            juju.offer('mymodel.mysql', endpoint=['db', 'log'], name='altname')
 
         Args:
             app: Application name to offer endpoints for.
             endpoint: Endpoint or endpoints to offer.
             name: Name of the offer. By default, the offer is named after the application.
         """
-        if ':' in app:
-            raise TypeError('must provide endpoint in "endpoint" argument not in "app"')
-        if not endpoint:
-            raise TypeError('must provide at least one endpoint')
-
-        app_endpoint = app + ':' + ','.join(endpoint)
+        if not isinstance(endpoint, str):
+            endpoint = ','.join(endpoint)
+        app_endpoint = f'{app}:{endpoint}'
         args = ['offer', app_endpoint]
         if name is not None:
             args.append(name)

--- a/tests/unit/test_offer.py
+++ b/tests/unit/test_offer.py
@@ -1,5 +1,3 @@
-import pytest
-
 import jubilant
 
 from . import mocks
@@ -9,34 +7,25 @@ def test(run: mocks.Run):
     run.handle(['juju', 'offer', 'mysql:db'])
     juju = jubilant.Juju()
 
-    juju.offer('mysql', 'db')
+    juju.offer('mysql', endpoint='db')
 
 
 def test_with_model(run: mocks.Run):
     run.handle(['juju', 'offer', '--model', 'mdl', 'mysql:db'])
     juju = jubilant.Juju(model='mdl')
 
-    juju.offer('mysql', 'db')
+    juju.offer('mysql', endpoint='db')
 
 
 def test_name(run: mocks.Run):
     run.handle(['juju', 'offer', 'mysql:db', 'nam'])
     juju = jubilant.Juju()
 
-    juju.offer('mysql', 'db', name='nam')
+    juju.offer('mysql', endpoint='db', name='nam')
 
 
 def test_multiple_endpoints(run: mocks.Run):
     run.handle(['juju', 'offer', 'mysql:db,log'])
     juju = jubilant.Juju()
 
-    juju.offer('mysql', 'db', 'log')
-
-
-def test_type_errors():
-    juju = jubilant.Juju()
-
-    with pytest.raises(TypeError):
-        juju.offer('mysql:db', 'name')  # endpoint in "app" argument
-    with pytest.raises(TypeError):
-        juju.offer('mysql')  # no endpoint provided
+    juju.offer('mysql', endpoint=['db', 'log'])


### PR DESCRIPTION
Per our API discussions. This is a bit more explicit and simpler, and provides better type checking by default.