### PR TITLE
fix: fix format of --bind argument for deploy

### DIFF
--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     'temp_model',
 ]
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -364,8 +364,9 @@ class Juju:
             args.extend(['--base', base])
         if bind is not None:
             if not isinstance(bind, str):
-                bind = ','.join(f'{k}={v}' for k, v in bind.items())
-            args.extend(['--bind', bind])
+                args.extend([f'--bind={k}={v}' for k, v in bind.items()])
+            else:
+                args.extend(['--bind', bind])
         if channel is not None:
             args.extend(['--channel', channel])
         if config is not None:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -364,9 +364,8 @@ class Juju:
             args.extend(['--base', base])
         if bind is not None:
             if not isinstance(bind, str):
-                args.extend([f'--bind={k}={v}' for k, v in bind.items()])
-            else:
-                args.extend(['--bind', bind])
+                bind = ' '.join(f'{k}={v}' for k, v in bind.items())
+            args.extend(['--bind', bind])
         if channel is not None:
             args.extend(['--channel', channel])
         if config is not None:

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -31,7 +31,7 @@ def test_all_args(run: mocks.Run):
             '--base',
             'ubuntu@22.04',
             '--bind',
-            'end1=space1,end2=space2',
+            'end1=space1 end2=space2',
             '--channel',
             'latest/edge',
             '--config',


### PR DESCRIPTION
Fix the format of the `--bind` argument to deploy from comma-separated to space-separated key=value pairs. See [Juju source](https://github.com/juju/juju/blob/214723de24e82f5d14fd255de0885092e0a4dd7c/cmd/juju/application/binding.go#L17-L24).
