### PR TITLE
chore: fix Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   tools:
     python: "3.12"
   jobs:
-    pre_install:
+    post_checkout:
     - git fetch --unshallow || true
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
This PR moves `git fetch ...` to the `post_checkout` job of the RTD build, matching the [latest starter pack](https://github.com/canonical/sphinx-docs-starter-pack/blob/9fc415a52147ea9fcd223a69b690c8b06ca056ab/.readthedocs.yaml#L14-L15). This appears to fix #133 - although I don't fully understand why (it might be coincidence).