### PR TITLE
feat: allow specifying cloud when creating model

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -116,9 +116,11 @@ class Juju:
     def add_model(
         self,
         model: str,
+        cloud: str | None = None,
         *,
         controller: str | None = None,
         config: Mapping[str, ConfigValue] | None = None,
+        credential: str | None = None,
     ) -> None:
         """Add a named model and set this instance's model to it.
 
@@ -128,18 +130,25 @@ class Juju:
 
         Args:
             model: Name of model to add.
+            cloud: Name of cloud or region (or cloud/region) to use for the model.
             controller: Name of controller to operate in. If not specified, use the current
                 controller.
             config: Model configuration as key-value pairs, for example,
                 ``{'image-stream': 'daily'}``.
+            credential: Name of cloud credential to use for the model.
         """
         args = ['add-model', '--no-switch', model]
+
+        if cloud is not None:
+            args.append(cloud)
 
         if controller is not None:
             args.extend(['--controller', controller])
         if config is not None:
             for k, v in config.items():
                 args.extend(['--config', _format_config(k, v)])
+        if credential is not None:
+            args.extend(['--credential', credential])
 
         self.cli(*args, include_model=False)
         self.model = model

--- a/tests/unit/test_add_model.py
+++ b/tests/unit/test_add_model.py
@@ -19,6 +19,7 @@ def test_all_args(run: mocks.Run):
             'add-model',
             '--no-switch',
             'm',
+            'lc',
             '--controller',
             'c',
             '--config',
@@ -27,10 +28,14 @@ def test_all_args(run: mocks.Run):
             'y=1',
             '--config',
             'z=ss',
+            '--credential',
+            'cc',
         ]
     )
     juju = jubilant.Juju()
 
-    juju.add_model('m', controller='c', config={'x': True, 'y': 1, 'z': 'ss'})
+    juju.add_model(
+        'm', 'lc', controller='c', config={'x': True, 'y': 1, 'z': 'ss'}, credential='cc'
+    )
 
     assert juju.model == 'm'


### PR DESCRIPTION
Add cloud and credential parameter to `add_model` method. This allows for targeting different clouds on the same controller when creating a model.

Fix: #142 