### PR TITLE
fix: "juju model" doesn't use --model argument

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -601,7 +601,7 @@ class Juju:
         if name is not None:
             args.append(name)
 
-        self.cli(*args)
+        self.cli(*args, include_model=False)
 
     def refresh(
         self,

--- a/tests/unit/test_offer.py
+++ b/tests/unit/test_offer.py
@@ -11,7 +11,8 @@ def test(run: mocks.Run):
 
 
 def test_with_model(run: mocks.Run):
-    run.handle(['juju', 'offer', '--model', 'mdl', 'mysql:db'])
+    # "juju offer" isn't a model-based command
+    run.handle(['juju', 'offer', 'mysql:db'])
     juju = jubilant.Juju(model='mdl')
 
     juju.offer('mysql', endpoint='db')


### PR DESCRIPTION
When implementing the `Juju.offer` method, I had overlooked that that command doesn't take a `--model` argument, and Juju complains when you do. Remove it.

This command doesn't have any integration tests, but update the unit tests with a negative test of this.

Fixes #147.