### PR TITLE
feat: add Status.get_units, include subordinates in all_* and any_*

### DIFF
--- a/jubilant/_all_any.py
+++ b/jubilant/_all_any.py
@@ -177,7 +177,7 @@ def _all_statuses_are(expected: str, status: Status, apps: Iterable[str]) -> boo
             return False
         if app_info.app_status.current != expected:
             return False
-        for unit_info in app_info.units.values():
+        for unit_info in status.get_units(app).values():
             if unit_info.workload_status.current != expected:
                 return False
     return True
@@ -193,7 +193,7 @@ def _any_status_is(expected: str, status: Status, apps: Iterable[str]) -> bool:
             continue
         if app_info.app_status.current == expected:
             return True
-        for unit_info in app_info.units.values():
+        for unit_info in status.get_units(app).values():
             if unit_info.workload_status.current == expected:
                 return True
     return False
@@ -207,7 +207,7 @@ def _all_agent_statuses_are(expected: str, status: Status, apps: Iterable[str]) 
         app_info = status.apps.get(app)
         if app_info is None:
             return False
-        for unit_info in app_info.units.values():
+        for unit_info in status.get_units(app).values():
             if unit_info.juju_status.current != expected:
                 return False
     return True

--- a/tests/unit/fake_statuses.py
+++ b/tests/unit/fake_statuses.py
@@ -218,3 +218,324 @@ DATABASE_WEBAPP_JSON = """
     }
 }
 """
+
+STATUS_ERRORS_JSON = """
+{
+    "model": {
+        "name": "tt",
+        "type": "caas",
+        "controller": "microk8s-localhost",
+        "cloud": "microk8s",
+        "version": "3.6.1",
+        "model-status": {
+            "status-error": "model status error!"
+        }
+    },
+    "machines": {
+        "machine-failed": {
+            "status-error": "machine status error!"
+        }
+    },
+    "applications": {
+        "app-failed": {
+            "status-error": "app status error!"
+        },
+        "unit-failed": {
+            "charm": "unit-failed",
+            "charm-origin": "origin",
+            "charm-name": "unit-failed",
+            "charm-rev": 0,
+            "exposed": false,
+            "units": {
+                "unit-failed/0": {
+                    "status-error": "unit status error!"
+                }
+            }
+        }
+    },
+    "offers": {
+        "offer-failed": {
+            "status-error": "offer status error!"
+        }
+    },
+    "application-endpoints": {
+        "remote-app-failed": {
+            "status-error": "remote app status error!"
+        }
+    }
+}
+"""
+
+SUBORDINATES_JSON = """
+{
+    "model": {
+        "name": "t",
+        "type": "iaas",
+        "controller": "lxd",
+        "cloud": "localhost",
+        "region": "localhost",
+        "version": "3.6.4",
+        "model-status": {
+            "current": "available",
+            "since": "09 Jun 2025 11:04:48+12:00"
+        },
+        "sla": "unsupported"
+    },
+    "machines": {
+        "1": {
+            "juju-status": {
+                "current": "started",
+                "since": "09 Jun 2025 11:14:50+12:00",
+                "version": "3.6.4"
+            },
+            "hostname": "juju-663cb8-1",
+            "dns-name": "10.103.56.99",
+            "ip-addresses": [
+                "10.103.56.99",
+                "fd42:63bf:36e0:2d9b:216:3eff:fe37:b62f"
+            ],
+            "instance-id": "juju-663cb8-1",
+            "machine-status": {
+                "current": "running",
+                "message": "Running",
+                "since": "09 Jun 2025 11:14:06+12:00"
+            },
+            "modification-status": {
+                "current": "applied",
+                "since": "09 Jun 2025 11:14:02+12:00"
+            },
+            "base": {
+                "name": "ubuntu",
+                "channel": "24.04"
+            },
+            "network-interfaces": {
+                "eth0": {
+                    "ip-addresses": [
+                        "10.103.56.99",
+                        "fd42:63bf:36e0:2d9b:216:3eff:fe37:b62f"
+                    ],
+                    "mac-address": "00:16:3e:37:b6:2f",
+                    "gateway": "10.103.56.1 10.103.56.1",
+                    "space": "alpha",
+                    "is-up": true
+                }
+            },
+            "constraints": "arch=amd64",
+            "hardware": "arch=amd64 cores=0 mem=0M virt-type=container"
+        },
+        "2": {
+            "juju-status": {
+                "current": "started",
+                "since": "09 Jun 2025 11:22:29+12:00",
+                "version": "3.6.4"
+            },
+            "hostname": "juju-663cb8-2",
+            "dns-name": "10.103.56.129",
+            "ip-addresses": [
+                "10.103.56.129",
+                "fd42:63bf:36e0:2d9b:216:3eff:fe4f:a835"
+            ],
+            "instance-id": "juju-663cb8-2",
+            "machine-status": {
+                "current": "running",
+                "message": "Running",
+                "since": "09 Jun 2025 11:21:40+12:00"
+            },
+            "modification-status": {
+                "current": "applied",
+                "since": "09 Jun 2025 11:21:35+12:00"
+            },
+            "base": {
+                "name": "ubuntu",
+                "channel": "24.04"
+            },
+            "network-interfaces": {
+                "eth0": {
+                    "ip-addresses": [
+                        "10.103.56.129",
+                        "fd42:63bf:36e0:2d9b:216:3eff:fe4f:a835"
+                    ],
+                    "mac-address": "00:16:3e:4f:a8:35",
+                    "gateway": "10.103.56.1 10.103.56.1",
+                    "space": "alpha",
+                    "is-up": true
+                }
+            },
+            "constraints": "arch=amd64",
+            "hardware": "arch=amd64 cores=0 mem=0M virt-type=container"
+        }
+    },
+    "applications": {
+        "nrpe": {
+            "charm": "nrpe",
+            "base": {
+                "name": "ubuntu",
+                "channel": "24.04"
+            },
+            "charm-origin": "charmhub",
+            "charm-name": "nrpe",
+            "charm-rev": 165,
+            "charm-channel": "latest/stable",
+            "exposed": false,
+            "application-status": {
+                "current": "blocked",
+                "message": "Nagios server not configured or related",
+                "since": "09 Jun 2025 11:17:02+12:00"
+            },
+            "relations": {
+                "general-info": [
+                    {
+                        "related-application": "ubun2",
+                        "interface": "juju-info",
+                        "scope": "container"
+                    },
+                    {
+                        "related-application": "ubuntu",
+                        "interface": "juju-info",
+                        "scope": "container"
+                    }
+                ]
+            },
+            "subordinate-to": [
+                "ubun2",
+                "ubuntu"
+            ],
+            "endpoint-bindings": {
+                "": "alpha",
+                "general-info": "alpha",
+                "local-monitors": "alpha",
+                "monitors": "alpha",
+                "nrpe": "alpha",
+                "nrpe-external-master": "alpha"
+            }
+        },
+        "ubun2": {
+            "charm": "ubuntu",
+            "base": {
+                "name": "ubuntu",
+                "channel": "24.04"
+            },
+            "charm-origin": "charmhub",
+            "charm-name": "ubuntu",
+            "charm-rev": 26,
+            "charm-channel": "latest/stable",
+            "exposed": false,
+            "application-status": {
+                "current": "active",
+                "since": "09 Jun 2025 11:22:39+12:00"
+            },
+            "relations": {
+                "juju-info": [
+                    {
+                        "related-application": "nrpe",
+                        "interface": "juju-info",
+                        "scope": "container"
+                    }
+                ]
+            },
+            "units": {
+                "ubun2/0": {
+                    "workload-status": {
+                        "current": "active",
+                        "since": "09 Jun 2025 11:22:39+12:00"
+                    },
+                    "juju-status": {
+                        "current": "idle",
+                        "since": "09 Jun 2025 11:22:41+12:00",
+                        "version": "3.6.4"
+                    },
+                    "leader": true,
+                    "machine": "2",
+                    "public-address": "10.103.56.129",
+                    "subordinates": {
+                        "nrpe/2": {
+                            "workload-status": {
+                                "current": "blocked",
+                                "message": "Nagios server not configured or related",
+                                "since": "09 Jun 2025 11:25:06+12:00"
+                            },
+                            "juju-status": {
+                                "current": "idle",
+                                "since": "09 Jun 2025 11:25:06+12:00",
+                                "version": "3.6.4"
+                            },
+                            "open-ports": [
+                                "icmp",
+                                "5666/tcp"
+                            ],
+                            "public-address": "10.103.56.129"
+                        }
+                    }
+                }
+            },
+            "version": "24.04"
+        },
+        "ubuntu": {
+            "charm": "ubuntu",
+            "base": {
+                "name": "ubuntu",
+                "channel": "24.04"
+            },
+            "charm-origin": "charmhub",
+            "charm-name": "ubuntu",
+            "charm-rev": 26,
+            "charm-channel": "latest/stable",
+            "exposed": false,
+            "application-status": {
+                "current": "active",
+                "since": "09 Jun 2025 11:15:00+12:00"
+            },
+            "relations": {
+                "juju-info": [
+                    {
+                        "related-application": "nrpe",
+                        "interface": "juju-info",
+                        "scope": "container"
+                    }
+                ]
+            },
+            "units": {
+                "ubuntu/1": {
+                    "workload-status": {
+                        "current": "active",
+                        "since": "09 Jun 2025 11:15:00+12:00"
+                    },
+                    "juju-status": {
+                        "current": "idle",
+                        "since": "09 Jun 2025 11:15:02+12:00",
+                        "version": "3.6.4"
+                    },
+                    "leader": true,
+                    "machine": "1",
+                    "public-address": "10.103.56.99",
+                    "subordinates": {
+                        "nrpe/1": {
+                            "workload-status": {
+                                "current": "blocked",
+                                "message": "Nagios server not configured or related",
+                                "since": "09 Jun 2025 11:17:02+12:00"
+                            },
+                            "juju-status": {
+                                "current": "idle",
+                                "since": "09 Jun 2025 11:17:02+12:00",
+                                "version": "3.6.4"
+                            },
+                            "leader": true,
+                            "open-ports": [
+                                "icmp",
+                                "5666/tcp"
+                            ],
+                            "public-address": "10.103.56.99"
+                        }
+                    }
+                }
+            },
+            "version": "24.04"
+        }
+    },
+    "storage": {},
+    "controller": {
+        "timestamp": "12:11:53+12:00"
+    }
+}
+"""


### PR DESCRIPTION
This adds Status.get_units to get an application's units, including the units of subordinate applications. It falls back to `apps[app].units` if the application is a principal (non-subordinate) app.

It also updates the all_* and any_* helpers like all_active and any_error to include units of subordinate apps.

The change to the all_* and any_* helpers is actually a breaking change, though I doubt it will affect users, except in a good way -- it's very likely what they expect already, and the docs say "Report whether any app or unit in status is active" without qualifiers, so it should include the units of subordinate apps.

Fixes #137