### PR TITLE
ci: run TIOBE checks in diagnostic mode

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -18,6 +18,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
 
+        # Note that these are dependencies for the tools that the TIOBE action will run,
+        # which is done in the global environment, rather than a venv, as we do with the
+        # unit tests.
+      - name: Install TICS dependencies
+        run: |
+          pip install flake8 pylint
+
       - name: Install uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
 
@@ -29,16 +36,10 @@ jobs:
           mkdir .report
           uvx coverage xml -o .report/coverage.xml
 
-        # Note that these are dependencies for the tools that the TIOBE action will run,
-        # which is done in the global environment, rather than a venv, as we do with the
-        # unit tests.
-      - name: Install dependencies
+      - name: Install project dependencies
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
-          uv venv
-          uv pip install flake8 pylint -r requirements.txt
-          source .venv/bin/activate
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          pip install -r requirements.txt
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -23,7 +23,7 @@ jobs:
         # unit tests.
       - name: Install TICS dependencies
         run: |
-          pip install flake8 pylint
+          sudo pip install flake8 pylint
 
       - name: Install uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -17,7 +17,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install dependencies
-        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata opentelemetry-sdk~=1.30 pydantic ops-scenario ops-tracing
+        run: |
+          pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata opentelemetry-sdk~=1.30 pydantic ops-scenario ops-tracing
+          mkdir .report
+          touch .report/coverage.xml
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0
         with:

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0
         with:
-          mode: qserver
+          mode:diagnostic
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           project: jubilant

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -36,7 +36,8 @@ jobs:
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
           pip install flake8 pylint -r requirements.txt
-          pylint .
+          whereis pylint
+          pylint jubilant
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -25,8 +25,9 @@ jobs:
       # and keeps this isolated.
       - name: Run unit tests
         run: |
+          make unit
           mkdir .report
-          uvx coverage xml -o .report/coverage.xml || touch .report/coverage.xml && echo 0
+          uvx coverage xml -o .report/coverage.xml
 
       # Note that these are dependencies for the tools that the TIOBE action will run,
       # which is done in the global environment, rather than a venv, as we do with the

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0
         with:
-          mode:diagnostic
+          mode: diagnostic
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           project: jubilant

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -36,11 +36,12 @@ jobs:
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
           pip install flake8 pylint -r requirements.txt
+          pylint .
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0
         with:
-          mode: diagnostic
+          mode: qserver
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           project: jubilant

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -35,7 +35,9 @@ jobs:
       - name: Install dependencies
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
-          pip install flake8 pylint -r requirements.txt
+          uv venv
+          uv pip install flake8 pylint -r requirements.txt
+          source .venv/bin/activate
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: TICS GitHub Action

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -14,33 +14,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-
       - name: Set up Python
         uses: actions/setup-python@v5
-
-        # Note that these are dependencies for the tools that the TIOBE action will run,
-        # which is done in the global environment, rather than a venv, as we do with the
-        # unit tests.
-      - name: Install TICS dependencies
-        run: |
-          sudo pip install flake8 pylint
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
-
-        # We could store the coverage report from the regular run, but this is cheap to do
-        # and keeps this isolated.
-      - name: Run unit tests
-        run: |
-          make unit
-          mkdir .report
-          uvx coverage xml -o .report/coverage.xml
-
-      - name: Install project dependencies
-        run: |
-          uv export --no-emit-project --frozen --no-hashes > requirements.txt
-          pip install -r requirements.txt
-
+      - name: Install dependencies
+        run: pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata opentelemetry-sdk~=1.30 pydantic ops-scenario ops-tracing
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0
         with:

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -37,7 +37,8 @@ jobs:
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
           pip install flake8 pylint -r requirements.txt
           whereis pylint
-          pylint jubilant
+          echo $PATH
+          pylint jubilant || exit 0
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -21,11 +21,16 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
 
+      # Note that these are dependencies for the tools that the TIOBE action will run,
+      # which is done in the global environment, rather than a venv, as we do with the
+      # unit tests.
       - name: Install dependencies
         run: |
-          pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata opentelemetry-sdk~=1.30 pydantic ops-scenario ops-tracing
+          uv export --no-emit-project --frozen --no-hashes > requirements.txt
+          pip install flake8 pylint -r requirements.txt
           mkdir .report
           touch .report/coverage.xml
+
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0
         with:

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -21,6 +21,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
 
+      # We could store the coverage report from the regular run, but this is cheap to do
+      # and keeps this isolated.
+      - name: Run unit tests
+        run: |
+          mkdir .report
+          uvx coverage xml -o .report/coverage.xml || touch .report/coverage.xml && echo 0
+
       # Note that these are dependencies for the tools that the TIOBE action will run,
       # which is done in the global environment, rather than a venv, as we do with the
       # unit tests.
@@ -28,8 +35,6 @@ jobs:
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
           pip install flake8 pylint -r requirements.txt
-          mkdir .report
-          touch .report/coverage.xml
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -36,9 +36,7 @@ jobs:
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
           pip install flake8 pylint -r requirements.txt
-          whereis pylint
-          echo $PATH
-          pylint jubilant || exit 0
+          echo PATH=$PATH >> $GITHUB_ENV
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -14,8 +14,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
       - name: Set up Python
         uses: actions/setup-python@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
+
       - name: Install dependencies
         run: |
           pip install tox~=4.2 coverage[toml] flake8 pylint websocket-client==1.* pyyaml==6.* pytest~=7.2 pytest-operator~=0.23 opentelemetry-api~=1.0 importlib-metadata opentelemetry-sdk~=1.30 pydantic ops-scenario ops-tracing

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
           pip install flake8 pylint -r requirements.txt
-          echo PATH=$PATH >> $GITHUB_ENV
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0


### PR DESCRIPTION
The output shows pylint being installed but TIOBE cannot find it. Maybe diagnostic mode will show why.

Note that we should be able to run the action against the branch so avoid merging this.