### PR TITLE
feat: add "overlays" parameter to Juju.deploy

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -328,6 +328,7 @@ class Juju:
         constraints: Mapping[str, str] | None = None,
         force: bool = False,
         num_units: int = 1,
+        overlays: Iterable[str | pathlib.Path] = (),
         resources: Mapping[str, str] | None = None,
         revision: int | None = None,
         storage: Mapping[str, str] | None = None,
@@ -352,6 +353,7 @@ class Juju:
             constraints: Hardware constraints for new machines, for example, ``{'mem': '8G'}``.
             force: If true, bypass checks such as supported bases.
             num_units: Number of units to deploy for principal charms.
+            overlays: File paths of bundles to overlay on the primary bundle, applied in order.
             resources: Specify named resources to use for deployment, for example:
                 ``{'bin': '/path/to/some/binary'}``.
             revision: Charmhub revision number to deploy.
@@ -360,6 +362,10 @@ class Juju:
                 to deploy to a new LXD container on machine 25, use ``lxd:25``.
             trust: If true, allows charm to run hooks that require access to cloud credentials.
         """
+        # Need this check because str is also an iterable of str.
+        if isinstance(overlays, str):
+            raise TypeError('overlays must be an iterable of str or pathlib.Path, not str')
+
         args = ['deploy', str(charm)]
         if app is not None:
             args.append(app)
@@ -387,6 +393,8 @@ class Juju:
             args.append('--force')
         if num_units != 1:
             args.extend(['--num-units', str(num_units)])
+        for overlay in overlays:
+            args.extend(['--overlay', str(overlay)])
         if resources is not None:
             for k, v in resources.items():
                 args.extend(['--resource', f'{k}={v}'])

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -1,5 +1,7 @@
 import pathlib
 
+import pytest
+
 import jubilant
 
 from . import mocks
@@ -45,6 +47,10 @@ def test_all_args(run: mocks.Run):
             '--force',
             '--num-units',
             '3',
+            '--overlay',
+            'one.yaml',
+            '--overlay',
+            'dir/two.yaml',
             '--resource',
             'bin=/path',
             '--revision',
@@ -69,6 +75,7 @@ def test_all_args(run: mocks.Run):
         constraints={'mem': '8G'},
         force=True,
         num_units=3,
+        overlays=['one.yaml', pathlib.Path('dir', 'two.yaml')],
         resources={'bin': '/path'},
         revision=42,
         storage={'data': 'tmpfs,1G'},
@@ -89,6 +96,13 @@ def test_list_args(run: mocks.Run):
     juju = jubilant.Juju()
 
     juju.deploy('charm', attach_storage=['stg1', 'stg2'], to=['to1', 'to2'])
+
+
+def test_overlays_str():
+    juju = jubilant.Juju()
+
+    with pytest.raises(TypeError):
+        juju.deploy('charm', overlays='bad')
 
 
 def test_path(run: mocks.Run):


### PR DESCRIPTION
This PR adds an `overlays: Iterable[str | pathlib.Path]` parameter to `Juju.deploy` to give access to the `juju deploy --overlay` argument.

I went back and forth about whether this should be named `overlay` and also allow a single overlay, with type `str | pathlib.Path | Iterable[str, pathlib.Path]`. However, I decided that the intent of this is a list applied in order (and the example @sed-i linked to in #155 uses a list). Note "Bundles" and "applied in order" in the Juju help output:

```
$ juju deploy --help | grep -i overlay
--overlay  (= )
    Bundles to overlay on the primary bundle, applied in order
```

Fixes #155.