### PR TITLE
feat: add AppStatus.leader_unit property

### DIFF
--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -254,6 +254,26 @@ class AppStatus:
         """Report whether the application status for this app is "waiting"."""
         return self.app_status.current == 'waiting'
 
+    @property
+    def leader_unit(self) -> UnitStatus:
+        """Return the leader unit's status.
+
+        For example, instead of this kind of duplication::
+
+            address = status.apps['snappass-test'].units['snappass-test/0'].address
+
+        You can simplify using ``leader_unit``:
+
+            address = status.apps['snappass-test'].leader_unit.address
+
+        Raises:
+            ValueError: if this application has no units marked as leader.
+        """
+        for unit in self.units.values():
+            if unit.leader:
+                return unit
+        raise ValueError('application has no leader unit')
+
 
 @dataclasses.dataclass(frozen=True)
 class EntityStatus:

--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -258,11 +258,11 @@ class AppStatus:
     def leader_unit(self) -> UnitStatus:
         """Return the leader unit's status.
 
-        For example, instead of this kind of duplication::
+        For example, instead of duplicating the application name::
 
             address = status.apps['snappass-test'].units['snappass-test/0'].address
 
-        You can simplify using ``leader_unit``:
+        You can simplify to::
 
             address = status.apps['snappass-test'].leader_unit.address
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -13,7 +13,7 @@ from . import helpers
 def setup(juju: jubilant.Juju):
     juju.deploy(helpers.find_charm('testdb'))
     juju.wait(
-        lambda status: status.apps['testdb'].units['testdb/0'].workload_status.current == 'unknown'
+        lambda status: status.apps['testdb'].leader_unit.workload_status.current == 'unknown'
     )
 
 

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -15,7 +15,7 @@ def setup(juju: jubilant.Juju):
 def test_deploy(juju: jubilant.Juju):
     # Setup has already done "juju deploy", this tests it.
     status = juju.status()
-    address = status.apps['snappass-test'].units['snappass-test/0'].address
+    address = status.apps['snappass-test'].leader_unit.address
     response = requests.get(f'http://{address}:5000/', timeout=10)
     response.raise_for_status()
     assert '<title>' in response.text

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -13,7 +13,7 @@ from . import helpers
 def setup(juju: jubilant.Juju):
     juju.deploy(helpers.find_charm('testdb'))
     juju.wait(
-        lambda status: status.apps['testdb'].units['testdb/0'].workload_status.current == 'unknown'
+        lambda status: status.apps['testdb'].leader_unit.workload_status.current == 'unknown'
     )
 
 


### PR DESCRIPTION
This simplifies code like:

```
address = status.apps['snappass-test'].units['snappass-test/0'].address
```

to

```
address = status.apps['snappass-test'].leader_unit.address
```

Also update integration tests to use the new property.

Fixes #128