### PR TITLE
feat: support multiple controllers

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -614,7 +614,8 @@ class Juju:
 
         Args:
             app: Application name to offer endpoints for.
-            controller: Controller to operate in.
+            controller: Name of controller to operate in. If not specified, use the current
+                controller.
             endpoint: Endpoint or endpoints to offer.
             name: Name of the offer. By default, the offer is named after the application.
         """

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -27,4 +27,4 @@ def temp_model(keep: bool = False, controller: str | None = None) -> Generator[J
         yield juju
     finally:
         if not keep:
-            juju.destroy_model(model, destroy_storage=True, force=True)
+            juju.destroy_model(juju.model, destroy_storage=True, force=True)

--- a/tests/unit/test_add_model.py
+++ b/tests/unit/test_add_model.py
@@ -38,4 +38,4 @@ def test_all_args(run: mocks.Run):
         'm', 'lc', controller='c', config={'x': True, 'y': 1, 'z': 'ss'}, credential='cc'
     )
 
-    assert juju.model == 'm'
+    assert juju.model == 'c:m'

--- a/tests/unit/test_juju_class.py
+++ b/tests/unit/test_juju_class.py
@@ -1,3 +1,5 @@
+import pytest
+
 import jubilant
 
 
@@ -9,10 +11,12 @@ def test_init_defaults():
     assert juju.cli_binary == 'juju'
 
 
-def test_init_args():
-    juju = jubilant.Juju(model='m', wait_timeout=7, cli_binary='/bin/juju3')
+@pytest.mark.parametrize('controller', [None, 'ctl'])
+def test_init_args(controller: str | None):
+    model_name = 'm' if controller is None else f'{controller}:m'
+    juju = jubilant.Juju(model=model_name, wait_timeout=7, cli_binary='/bin/juju3')
 
-    assert juju.model == 'm'
+    assert juju.model == model_name
     assert juju.wait_timeout == 7
     assert juju.cli_binary == '/bin/juju3'
 

--- a/tests/unit/test_offer.py
+++ b/tests/unit/test_offer.py
@@ -18,6 +18,13 @@ def test_with_model(run: mocks.Run):
     juju.offer('mysql', endpoint='db')
 
 
+def test_with_controller(run: mocks.Run):
+    run.handle(['juju', 'offer', 'mysql:db', '--controller', 'otherc'])
+    juju = jubilant.Juju(model='ctl:mdl')
+
+    juju.offer('mysql', endpoint='db', controller='otherc')
+
+
 def test_name(run: mocks.Run):
     run.handle(['juju', 'offer', 'mysql:db', 'nam'])
     juju = jubilant.Juju()


### PR DESCRIPTION
All the currently implemented `juju` commands that support `--model` support both plain `{model}` and `{controller:}{model}` as values. Use this to explicitly support multiple controllers by allowing `Juju.model` to be a local controller plain model, or an external model in the form `controller:model`.

The charmer provides the controller when creating the `Juju` instance, like `juju = Juju(model='my-controller:my-model')`, and can then use all of the methods that use `--model` under the hood normally.

For `add_model()`, store the model name in the local instance as `controller:model` if a controller is provided.

For `offer()`, a `--controller` argument is required, so add `controller: str|None=None` as an argument for that method and pass it to `juju` appropriately.

In the test helper `temp_model()`, ensure that the model is destroyed correctly if a controller is passed in.