### PR TITLE
ci: move TIOBE workflow to self-hosted runners

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   TICS:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, reactive, amd64, tiobe, noble]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We've been [asked](https://chat.canonical.com/canonical/pl/yku51kozbtbdmbnaodxzgitkwh) to move the TIOBE workflow to self-hosted runners.

This is meant to optimise the time and bandwidth usage of Canonical's TICS pipelines for static code analysis in GitHub. Two thirds of the GitHub TICS pipelines under Canonical org are using them, but they want it to be closer to 100%.

I've used the `tiobe` runner (medium sized) as it seems like the static analysis for this repo shouldn't need large/2xlarge.