### PR TITLE
feat: have temp_model forward "cloud" and other args to add_model

### DIFF
--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 import contextlib
 import secrets
+from collections.abc import Mapping
 from typing import Generator
 
-from ._juju import Juju
+from ._juju import ConfigValue, Juju
 
 
 @contextlib.contextmanager
-def temp_model(keep: bool = False, controller: str | None = None) -> Generator[Juju]:
+def temp_model(
+    keep: bool = False,
+    controller: str | None = None,
+    cloud: str | None = None,
+    config: Mapping[str, ConfigValue] | None = None,
+    credential: str | None = None,
+) -> Generator[Juju]:
     """Context manager to create a temporary model for running tests in.
 
     This creates a new model with a random name in the format ``jubilant-abcd1234``, and destroys
@@ -29,10 +36,14 @@ def temp_model(keep: bool = False, controller: str | None = None) -> Generator[J
     Args:
         keep: If true, keep the created model around when the context manager exits.
         controller: Name of controller where the temporary model will be added.
+        cloud: Name of cloud or region (or cloud/region) to use for the temporary model.
+        config: Temporary model configuration as key-value pairs, for example,
+            ``{'image-stream': 'daily'}``.
+        credential: Name of cloud credential to use for the temporary model.
     """
     juju = Juju()
     model = 'jubilant-' + secrets.token_hex(4)  # 4 bytes (8 hex digits) should be plenty
-    juju.add_model(model, controller=controller)
+    juju.add_model(model, cloud=cloud, controller=controller, config=config, credential=credential)
     try:
         yield juju
     finally:

--- a/tests/unit/test_test_helpers.py
+++ b/tests/unit/test_test_helpers.py
@@ -42,7 +42,25 @@ def test_defaults(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
 
 def test_other_args(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr('secrets.token_hex', mock_token_hex)
-    run.handle(['juju', 'add-model', '--no-switch', 'jubilant-abcd1234', '--controller', 'ctl'])
+    run.handle(
+        [
+            'juju',
+            'add-model',
+            '--no-switch',
+            'jubilant-abcd1234',
+            'localhost',
+            '--controller',
+            'ctl',
+            '--config',
+            'x=true',
+            '--config',
+            'y=1',
+            '--config',
+            'z=ss',
+            '--credential',
+            'cc',
+        ]
+    )
     run.handle(['juju', 'deploy', '--model', 'ctl:jubilant-abcd1234', 'app1'])
     run.handle(
         [
@@ -55,7 +73,12 @@ def test_other_args(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
         ]
     )
 
-    with jubilant.temp_model(keep=False, controller='ctl') as juju:
+    with jubilant.temp_model(
+        controller='ctl',
+        config={'x': True, 'y': 1, 'z': 'ss'},
+        credential='cc',
+        cloud='localhost',
+    ) as juju:
         assert juju.model == 'ctl:jubilant-abcd1234'
         assert len(run.calls) == 1
         assert run.calls[0].args[1] == 'add-model'
@@ -73,10 +96,34 @@ def test_other_args(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
 
 def test_other_args_keep(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr('secrets.token_hex', mock_token_hex)
-    run.handle(['juju', 'add-model', '--no-switch', 'jubilant-abcd1234', '--controller', 'ctl'])
+    run.handle(
+        [
+            'juju',
+            'add-model',
+            '--no-switch',
+            'jubilant-abcd1234',
+            'localhost',
+            '--controller',
+            'ctl',
+            '--config',
+            'x=true',
+            '--config',
+            'y=1',
+            '--config',
+            'z=ss',
+            '--credential',
+            'cc',
+        ]
+    )
     run.handle(['juju', 'deploy', '--model', 'ctl:jubilant-abcd1234', 'app1'])
 
-    with jubilant.temp_model(keep=True, controller='ctl') as juju:
+    with jubilant.temp_model(
+        keep=True,
+        controller='ctl',
+        config={'x': True, 'y': 1, 'z': 'ss'},
+        credential='cc',
+        cloud='localhost',
+    ) as juju:
         assert juju.model == 'ctl:jubilant-abcd1234'
         assert len(run.calls) == 1
         assert run.calls[0].args[1] == 'add-model'


### PR DESCRIPTION
Allows users to pass the cloud option to jubilant.temp_model for instances with multiple clouds in the same controller, ie testing machine charms integrating with k8s charms.