### PR TITLE
ci: fix installing TIOBE dependencies on the self-hosted runners

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv export --no-emit-project --frozen --no-hashes > requirements.txt
-          pip install flake8 pylint -r requirements.txt
+          pip install flake8 pylint -r requirements.txt --break-system-packages
 
       - name: TICS GitHub Action
         uses: tiobe/tics-github-action@009979693978bfefad2ad15c1020066694968dc7  # v3.4.0


### PR DESCRIPTION
Moving to the self-hosted runners (#167) broke installing the dependencies that the TIOBE "tics" tool requires.

Force installing those as they were before by using `--break-system-packages`.

It would be much better if we were *not* using the system packages (or, ideally, if the tics tool handled installing dependencies itself). It seems like we can activate a venv (like [pgbouncer does](https://github.com/canonical/pgbouncer-operator/blob/main/.github/workflows/tiobe_scan.yaml)), so feel free to push back and suggest doing that. I did try using a venv in some TIOBE work in the past and had difficulty, but there were other issues happening at the time so it may be simple after all. It's unfortunately difficult to test TIOBE workflows unless the branch lives in the organisation repo rather than the fork.