### PR TITLE
ci: run secscan to do a security scan and generate an SBOM on publish

### DIFF
--- a/.github/.sbomber-manifest-sdist.yaml
+++ b/.github/.sbomber-manifest-sdist.yaml
@@ -1,0 +1,18 @@
+clients:
+  sbom:
+      service_url: https://sbom-request.canonical.com
+      department: charm_engineering
+      email: tony.meyer@canonical.com
+      team: charm_tech
+  secscan: {}
+
+
+artifacts:
+  - name: 'ops'
+    type: 'sdist'
+    compression: 'gz'
+    ssdlc_params:
+        name: 'jubilant'
+        version: ''
+        channel: 'stable'
+        cycle: '25.10'

--- a/.github/.sbomber-manifest-sdist.yaml
+++ b/.github/.sbomber-manifest-sdist.yaml
@@ -8,7 +8,7 @@ clients:
 
 
 artifacts:
-  - name: 'ops'
+  - name: 'jubilant'
     type: 'sdist'
     compression: 'gz'
     ssdlc_params:

--- a/.github/.sbomber-manifest-wheel.yaml
+++ b/.github/.sbomber-manifest-wheel.yaml
@@ -1,0 +1,16 @@
+clients:
+  sbom:
+      service_url: https://sbom-request.canonical.com
+      department: charm_engineering
+      email: tony.meyer@canonical.com
+      team: charm_tech
+  secscan: {}
+
+
+artifacts:
+  - name: 'jubilant'
+    type: 'wheel'
+    ssdlc_params:
+        name: 'jubilant'
+        channel: 'stable'
+        cycle: '25.10'

--- a/.github/.sbomber-manifest-wheel.yaml
+++ b/.github/.sbomber-manifest-wheel.yaml
@@ -13,4 +13,5 @@ artifacts:
     ssdlc_params:
         name: 'jubilant'
         channel: 'stable'
+        version: ''
         cycle: '25.10'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  secscan:
+    uses: ./.github/workflows/secscan.yaml

--- a/.github/workflows/secscan.yaml
+++ b/.github/workflows/secscan.yaml
@@ -1,0 +1,60 @@
+name: SBOM and secscan
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+permissions: {}
+
+jobs:
+    scan:
+        strategy:
+          fail-fast: false
+          matrix:
+            manifest: [sdist, wheel]
+
+        name: SBOM generation
+        runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
+            with:
+              persist-credentials: false
+          - name: Install dependencies
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y libapt-pkg-dev
+              sudo apt install -y python3-apt
+          - name: Checkout security scanner
+            uses: actions/checkout@v4
+            with:
+              repository: canonical/sbomber
+              path: scanner
+              token: ${{ secrets.SBOMBER_TOKEN }}
+              persist-credentials: false
+          - name: Install uv
+            uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
+          - name: Install secscan cli
+            run: |
+              sudo snap install canonical-secscan-client
+              sudo snap connect canonical-secscan-client:home system:home
+          - name: Prepare the artifacts
+            run: |
+              cd scanner
+              ./sbomber prepare ../.github/.sbomber-manifest-${{ matrix.manifest }}.yaml
+          - name: Submit the artifacts
+            run: |
+              cd scanner
+              ./sbomber submit
+          - name: Wait for the scans to finish
+            run: |
+              cd scanner
+              ./sbomber poll --wait --timeout 30
+          - name: Download the reports
+            run: |
+              cd scanner && ./sbomber download
+          - name: Upload reports
+            uses: actions/upload-artifact@v4
+            with:
+              name: secscan-report-upload-${{ matrix.manifest }}
+              path: ./scanner/reports/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ jubilant.egg-info
 *.charm
 # sbomber tool
 .statefile.yaml
+pkgs/
+reports/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ jubilant.egg-info
 .coverage
 .report
 *.charm
+# sbomber tool
+.statefile.yaml


### PR DESCRIPTION
At the conclusion of the publishing workflow, use the secscan tool to generate an SBOM and run a security scan, and store those results with the workflow.

Although there are only two artefacts to run against, the workflow uses the [sbomber](https://github.com/canonical/sbomber) tool to simplify the process and keep it consistent with other Charm Tech projects.

The secscan tool can only be run in the Canonical network, so the workflow is set to use a hosted runner. This prevents testing the workflow in my fork, but it is very similar to the one in canonical/operator that works.

TODO:
* [ ] Once we hear back from the security team, either add in the required secret to get sbomber package, or (hopefully) remove that requirement.
* [x] Wait until the [feature for automatic version detection](https://github.com/canonical/sbomber/pull/32) is merged