### PR TITLE
docs: update links and config for switch to documentation.ubuntu.com/jubilant

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Jubilant is a Python library that wraps the [Juju](https://juju.is/) CLI for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
 
-You should consider switching to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) (and they probably do). Jubilant has an API you'll pick up quickly, and it avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`. Read our [design goals](https://canonical-jubilant.readthedocs-hosted.com/explanation/design-goals).
+You should consider switching to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) (and they probably do). Jubilant has an API you'll pick up quickly, and it avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`. Read our [design goals](https://documentation.ubuntu.com/jubilant/explanation/design-goals).
 
 Jubilant 1.0.0 was released in April 2025. We will try our best to avoid making breaking changes to the API after this point.
 
-[**Read the full documentation**](https://canonical-jubilant.readthedocs-hosted.com/)
+[**Read the full documentation**](https://documentation.ubuntu.com/jubilant/)
 
 
 ## Using Jubilant

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ copyright = "%s, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-jubilant.readthedocs-hosted.com/"
+ogp_site_url = "https://documentation.ubuntu.com/jubilant/"
 
 
 # Preview name of the documentation website
@@ -168,7 +168,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'jubilant'
 
 
 # Template and asset locations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 Homepage = "https://github.com/canonical/jubilant"
 Repository = "https://github.com/canonical/jubilant"
 Issues = "https://github.com/canonical/jubilant/issues"
-Documentation = "https://canonical-jubilant.readthedocs-hosted.com/"
+Documentation = "https://documentation.ubuntu.com/jubilant/"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
This PR updates hardcoded doc links to point to the new location of the docs: https://documentation.ubuntu.com/jubilant/

I'm also updating the slug, which should avoid unstyled error pages (it seemed to work for Pebble in https://github.com/canonical/pebble/pull/573).