### PR TITLE
docs: update tutorial with info about deploying .charm files

### DIFF
--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -93,6 +93,7 @@ A few things to note about the fixture:
 * If any of the tests fail, it uses `juju.debug_log` to display the last 1000 lines of `juju debug-log` output.
 * It is module-scoped, like pytest-operator's `ops_test` fixture. This means that a new model is created for every `test_*.py` file, but not for every test.
 
+(how_to_migrate_an_application_fixture)=
 ### An application fixture
 
 If you don't want to deploy your application in each test, you can add a module-scoped `app` fixture that deploys your charm and waits for it to go active.

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -82,6 +82,8 @@ def test_deploy(juju: jubilant.Juju):
     juju.wait(lambda status: jubilant.all_active(status, 'snappass-test'))
 ```
 
+This test deploys the `snappass-test` charm from Charmhub. To deploy a charm from a `.charm` file (created by `charmcraft pack`), use `juju.deploy('/path/to/mycharm.charm')`. For an example, see [](#how_to_migrate_an_application_fixture).
+
 You may want to adjust the [scope](https://docs.pytest.org/en/stable/how-to/fixtures.html#fixture-scopes) of your `juju` fixture. For example, to create a new model for every test function (pytest's default behavior), omit the scope:
 
 ```python


### PR DESCRIPTION
As [discussed in Matrix](https://matrix.to/#/!eNCNzcteYUDDYpStsu:ubuntu.com/$wSdesbcVcRYi3t6wKinxcuv7nJ7hLYVW2HDEVP4d4mk), I feel it would be helpful if the tutorial mentions about deploying from `.charm` files vs Charmhub. This PR adds a couple of sentences to do that.

**[Preview doc](https://canonical-ubuntu-documentation-library--187.com.readthedocs.build/jubilant/tutorial/getting-started/#write-a-charm-integration-test)**