### PR TITLE
fix: add timeout to temp_model destroy-model to fix microk8s issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-dev:  # Install development tooling
 	uv tool install zizmor
 
 integration-k8s:  # Run K8s integration tests on Juju, eg: make integration ARGS='-k test_deploy'
-	uv run pytest tests/integration -vv --log-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m 'not machine' $(ARGS)
+	uv run pytest tests/integration -vv --log-cli --log-cli-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m 'not machine' $(ARGS)
 
 integration-machine:  # Run machine integration tests on Juju, eg: make integration-machine ARGS='-k test_ssh'
 	uv run pytest tests/integration -vv --log-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m machine $(ARGS)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ integration-k8s:  # Run K8s integration tests on Juju, eg: make integration ARGS
 	uv run pytest tests/integration -vv --log-cli-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m 'not machine' $(ARGS)
 
 integration-machine:  # Run machine integration tests on Juju, eg: make integration-machine ARGS='-k test_ssh'
-	uv run pytest tests/integration -vv --log-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m machine $(ARGS)
+	uv run pytest tests/integration -vv --log-cli-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m machine $(ARGS)
 
 lint:  # Perform linting and static type checks
 	uv run ruff check

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install-dev:  # Install development tooling
 	uv tool install zizmor
 
 integration-k8s:  # Run K8s integration tests on Juju, eg: make integration ARGS='-k test_deploy'
-	uv run pytest tests/integration -vv --log-cli --log-cli-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m 'not machine' $(ARGS)
+	uv run pytest tests/integration -vv --log-cli-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m 'not machine' $(ARGS)
 
 integration-machine:  # Run machine integration tests on Juju, eg: make integration-machine ARGS='-k test_ssh'
 	uv run pytest tests/integration -vv --log-level=INFO --log-format="%(asctime)s %(levelname)s %(message)s" -m machine $(ARGS)

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -305,6 +305,7 @@ class Juju:
         stdin: str | None = None,
         log: bool = True,
         timeout: float | None = None,
+        capture_output: bool = True,
     ) -> tuple[str, str]:
         """Run a Juju CLI command and return its standard output and standard error."""
         if include_model and self.model is not None:
@@ -315,7 +316,7 @@ class Juju:
             process = subprocess.run(
                 [self.cli_binary, *args],
                 check=True,
-                capture_output=True,
+                capture_output=capture_output,
                 encoding='utf-8',
                 input=stdin,
                 timeout=timeout,
@@ -551,7 +552,7 @@ class Juju:
             args.append('--destroy-storage')
         if force:
             args.append('--force')
-        self._cli(*args, include_model=False, timeout=timeout)
+        self._cli(*args, include_model=False, timeout=timeout, capture_output=False)
         if model == self.model:
             self.model = None
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -299,7 +299,12 @@ class Juju:
         return stdout
 
     def _cli(
-        self, *args: str, include_model: bool = True, stdin: str | None = None, log: bool = True
+        self,
+        *args: str,
+        include_model: bool = True,
+        stdin: str | None = None,
+        log: bool = True,
+        timeout: float | None = None,
     ) -> tuple[str, str]:
         """Run a Juju CLI command and return its standard output and standard error."""
         if include_model and self.model is not None:
@@ -313,6 +318,7 @@ class Juju:
                 capture_output=True,
                 encoding='utf-8',
                 input=stdin,
+                timeout=timeout,
             )
         except subprocess.CalledProcessError as e:
             raise CLIError(e.returncode, e.cmd, e.stdout, e.stderr) from None
@@ -525,6 +531,7 @@ class Juju:
         *,
         destroy_storage: bool = False,
         force: bool = False,
+        timeout: float | None = None,
     ) -> None:
         """Terminate all machines (or containers) and resources for a model.
 
@@ -535,13 +542,14 @@ class Juju:
             model: Name of model to destroy.
             destroy_storage: If true, destroy all storage instances in the model.
             force: If true, force model destruction and ignore any errors.
+            timeout: TODO: temporary, for testing
         """
         args = ['destroy-model', model, '--no-prompt']
         if destroy_storage:
             args.append('--destroy-storage')
         if force:
             args.append('--force')
-        self.cli(*args, include_model=False)
+        self._cli(*args, include_model=False, timeout=timeout)
         if model == self.model:
             self.model = None
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -547,7 +547,7 @@ class Juju:
             args.append('--destroy-storage')
         if force:
             args.append('--force')
-        self._cli(*args, include_model=False)
+        self.cli(*args, include_model=False)
         if model == self.model:
             self.model = None
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -322,6 +322,8 @@ class Juju:
             )
         except subprocess.CalledProcessError as e:
             raise CLIError(e.returncode, e.cmd, e.stdout, e.stderr) from None
+        except subprocess.TimeoutExpired as e:
+            raise CLIError(-1, e.cmd, e.stdout, e.stderr) from None
         return (process.stdout, process.stderr)
 
     @overload

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -547,12 +547,20 @@ class Juju:
             force: If true, force model destruction and ignore any errors.
             timeout: TODO: temporary, for testing
         """
-        args = ['destroy-model', model, '--no-prompt']
+        args = ['destroy-model', model, '--no-prompt', '--debug']
         if destroy_storage:
             args.append('--destroy-storage')
         if force:
             args.append('--force')
-        self._cli(*args, include_model=False, timeout=timeout, capture_output=False)
+        try:
+            self._cli(*args, include_model=False, timeout=timeout, capture_output=False)
+        except CLIError:
+            try:
+                log = self.debug_log(limit=1000)
+                print(log, end='')
+            except CLIError as e2:
+                print(f'Error fetching debug log: {e2}')
+            raise
         if model == self.model:
             self.model = None
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -556,7 +556,8 @@ class Juju:
             self._cli(*args, include_model=False, timeout=timeout, capture_output=False)
         except CLIError:
             try:
-                log = self.debug_log(limit=1000)
+                args = ['debug-log', '--limit', '1000', '--model', 'controller']
+                log = self.cli(*args, include_model=False)
                 print(log, end='')
             except CLIError as e2:
                 print(f'Error fetching debug log: {e2}')

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -49,4 +49,4 @@ def temp_model(
     finally:
         if not keep:
             assert juju.model is not None
-            juju.destroy_model(juju.model, destroy_storage=True, force=True)
+            juju.destroy_model(juju.model, destroy_storage=True, force=True, timeout=5 * 60)

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -25,6 +25,9 @@ def temp_model(
     This creates a new model with a random name in the format ``jubilant-abcd1234``, and destroys
     it and its storage when the context manager exits.
 
+    If destroying the model takes longer than 10 minutes, log an error and return successfully.
+    This is mainly to work around issues with Microk8s destroy-model hanging indefinitely.
+
     Provides a :class:`Juju` instance to operate on.
 
     If you want to configure its parameters, such as ``wait_timeout``, set the appropriate
@@ -54,6 +57,8 @@ def temp_model(
         if not keep:
             assert juju.model is not None
             try:
+                # We're not using juju.destroy_model() here, as it doesn't have a timeout
+                # parameter. If we add such a parameter, we can update this.
                 args = ['destroy-model', juju.model, '--no-prompt', '--destroy-storage', '--force']
                 juju._cli(*args, include_model=False, timeout=10 * 60)
                 juju.model = None

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -12,6 +12,7 @@ class Call:
     stdin: str | None
     stdout: str
     stderr: str
+    timeout: float | None
 
 
 class Run:
@@ -40,6 +41,7 @@ class Run:
         capture_output: bool = False,
         encoding: str | None = None,
         input: str | None = None,
+        timeout: float | None = None,
     ) -> subprocess.CompletedProcess[str]:
         args_tuple = tuple(args)
         assert check is True
@@ -49,7 +51,14 @@ class Run:
 
         returncode, stdout, stderr = self._commands[args_tuple]
         self.calls.append(
-            Call(args=args_tuple, returncode=returncode, stdin=input, stdout=stdout, stderr=stderr)
+            Call(
+                args=args_tuple,
+                returncode=returncode,
+                stdin=input,
+                stdout=stdout,
+                stderr=stderr,
+                timeout=timeout,
+            )
         )
         if returncode != 0:
             raise subprocess.CalledProcessError(

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -45,7 +45,7 @@ class Run:
     ) -> subprocess.CompletedProcess[str]:
         args_tuple = tuple(args)
         assert check is True
-        #        assert capture_output is True
+        assert capture_output is True
         assert encoding == 'utf-8'
         assert args_tuple in self._commands, f'unhandled command {args}'
 

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -45,7 +45,7 @@ class Run:
     ) -> subprocess.CompletedProcess[str]:
         args_tuple = tuple(args)
         assert check is True
-        assert capture_output is True
+        #        assert capture_output is True
         assert encoding == 'utf-8'
         assert args_tuple in self._commands, f'unhandled command {args}'
 

--- a/tests/unit/test_destroy_model.py
+++ b/tests/unit/test_destroy_model.py
@@ -4,7 +4,7 @@ from . import mocks
 
 
 def test_destroy_this(run: mocks.Run):
-    run.handle(['juju', 'destroy-model', 'initial', '--no-prompt'])
+    run.handle(['juju', 'destroy-model', 'initial', '--no-prompt', '--debug'])
     juju = jubilant.Juju(model='initial')
 
     juju.destroy_model('initial')
@@ -13,7 +13,7 @@ def test_destroy_this(run: mocks.Run):
 
 
 def test_destroy_other(run: mocks.Run):
-    run.handle(['juju', 'destroy-model', 'other', '--no-prompt'])
+    run.handle(['juju', 'destroy-model', 'other', '--no-prompt', '--debug'])
     juju = jubilant.Juju(model='initial')
 
     juju.destroy_model('other')
@@ -22,7 +22,9 @@ def test_destroy_other(run: mocks.Run):
 
 
 def test_args(run: mocks.Run):
-    run.handle(['juju', 'destroy-model', 'bad', '--no-prompt', '--destroy-storage', '--force'])
+    run.handle(
+        ['juju', 'destroy-model', 'bad', '--no-prompt', '--debug', '--destroy-storage', '--force']
+    )
     juju = jubilant.Juju()
 
     juju.destroy_model('bad', destroy_storage=True, force=True)

--- a/tests/unit/test_destroy_model.py
+++ b/tests/unit/test_destroy_model.py
@@ -4,7 +4,7 @@ from . import mocks
 
 
 def test_destroy_this(run: mocks.Run):
-    run.handle(['juju', 'destroy-model', 'initial', '--no-prompt', '--debug'])
+    run.handle(['juju', 'destroy-model', 'initial', '--no-prompt'])
     juju = jubilant.Juju(model='initial')
 
     juju.destroy_model('initial')
@@ -13,7 +13,7 @@ def test_destroy_this(run: mocks.Run):
 
 
 def test_destroy_other(run: mocks.Run):
-    run.handle(['juju', 'destroy-model', 'other', '--no-prompt', '--debug'])
+    run.handle(['juju', 'destroy-model', 'other', '--no-prompt'])
     juju = jubilant.Juju(model='initial')
 
     juju.destroy_model('other')
@@ -22,9 +22,7 @@ def test_destroy_other(run: mocks.Run):
 
 
 def test_args(run: mocks.Run):
-    run.handle(
-        ['juju', 'destroy-model', 'bad', '--no-prompt', '--debug', '--destroy-storage', '--force']
-    )
+    run.handle(['juju', 'destroy-model', 'bad', '--no-prompt', '--destroy-storage', '--force'])
     juju = jubilant.Juju()
 
     juju.destroy_model('bad', destroy_storage=True, force=True)

--- a/tests/unit/test_test_helpers.py
+++ b/tests/unit/test_test_helpers.py
@@ -20,6 +20,7 @@ def test_defaults(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
             'destroy-model',
             'jubilant-abcd1234',
             '--no-prompt',
+            '--debug',
             '--destroy-storage',
             '--force',
         ]
@@ -68,6 +69,7 @@ def test_other_args(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
             'destroy-model',
             'ctl:jubilant-abcd1234',
             '--no-prompt',
+            '--debug',
             '--destroy-storage',
             '--force',
         ]

--- a/tests/unit/test_test_helpers.py
+++ b/tests/unit/test_test_helpers.py
@@ -1,3 +1,7 @@
+import logging
+import subprocess
+from typing import Any
+
 import pytest
 
 import jubilant
@@ -20,7 +24,6 @@ def test_defaults(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
             'destroy-model',
             'jubilant-abcd1234',
             '--no-prompt',
-            '--debug',
             '--destroy-storage',
             '--force',
         ]
@@ -69,7 +72,6 @@ def test_other_args(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
             'destroy-model',
             'ctl:jubilant-abcd1234',
             '--no-prompt',
-            '--debug',
             '--destroy-storage',
             '--force',
         ]
@@ -137,3 +139,28 @@ def test_other_args_keep(run: mocks.Run, monkeypatch: pytest.MonkeyPatch):
 
     assert juju.model == 'ctl:jubilant-abcd1234'
     assert len(run.calls) == 2
+
+
+def test_destroy_timeout(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    def mock_run(args: 'list[str]', **kwargs: 'dict[str, Any]'):
+        if args[1] == 'add-model':
+            return subprocess.CompletedProcess(args, 0, '', '')
+        assert args == [
+            'juju',
+            'destroy-model',
+            'jubilant-abcd1234',
+            '--no-prompt',
+            '--destroy-storage',
+            '--force',
+        ]
+        assert kwargs['timeout'] == 10 * 60
+        raise subprocess.TimeoutExpired(args, 10 * 60, 'STDOUT', 'STDERR')
+
+    monkeypatch.setattr('subprocess.run', mock_run)
+    monkeypatch.setattr('secrets.token_hex', mock_token_hex)
+    caplog.set_level(logging.ERROR, logger='jubilant')
+
+    with jubilant.temp_model():
+        pass
+
+    assert 'timeout destroying model' in caplog.records[0].getMessage()


### PR DESCRIPTION
The integration-k8s tests are hanging ([example here](https://github.com/canonical/jubilant/actions/runs/17312074131/job/49297452945)) just after the second-to-last test (test_secrets.test_get_all_secrets) and then timing out after 6h. Juju hangs on cleanup -- after talking to the Juju team, this is a Microk8s issue, so work around it here.

We could only do this for microk8s, but it seems like when using a temp model, destroying it should never take longer than a reasonable time (10 minutes seems ample), so just add a timeout to the `juju destroy-model` in `temp_model()` always.