### PR TITLE
chore: run integration tests against Juju 4/beta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,11 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-k8s
       cancel-in-progress: true
 
+    strategy:
+      fail-fast: false
+      matrix:
+        juju-channel: ['3/stable', '4/beta']
+
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -64,7 +69,7 @@ jobs:
         run: sudo snap install --classic concierge
 
       - name: Prepare Juju
-        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=3.x/stable -p microk8s
+        run: sudo concierge prepare --verbose --juju-channel=${{ juju-channel }} --charmcraft-channel=3.x/stable -p microk8s
 
       - name: Pack test charms
         run: make pack
@@ -79,6 +84,11 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-machine
       cancel-in-progress: true
 
+    strategy:
+      fail-fast: false
+      matrix:
+        juju-channel: ['3/stable', '4/beta']
+
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -90,7 +100,7 @@ jobs:
         run: sudo snap install --classic concierge
 
       - name: Prepare Juju
-        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=3.x/stable -p machine
+        run: sudo concierge prepare --verbose --juju-channel=${{ juju-channel }} --charmcraft-channel=3.x/stable -p machine
 
       - name: Pack test charms
         run: make pack

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
         run: sudo snap install --classic concierge
 
       - name: Prepare Juju
-        run: sudo concierge prepare --verbose --juju-channel=${{ juju-channel }} --charmcraft-channel=3.x/stable -p microk8s
+        run: sudo concierge prepare --verbose --juju-channel=${{ matrix.juju-channel }} --charmcraft-channel=3.x/stable -p microk8s
 
       - name: Pack test charms
         run: make pack
@@ -105,7 +105,7 @@ jobs:
         run: sudo snap install --classic concierge
 
       - name: Prepare Juju
-        run: sudo concierge prepare --verbose --juju-channel=${{ juju-channel }} --charmcraft-channel=3.x/stable -p machine
+        run: sudo concierge prepare --verbose --juju-channel=${{ matrix.juju-channel }} --charmcraft-channel=3.x/stable -p machine
 
       - name: Pack test charms
         run: make pack

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,8 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-k8s
       cancel-in-progress: true
 
+    continue-on-error: ${{ matrix.juju-channel == '4/beta' }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +78,7 @@ jobs:
 
       - name: Run integration tests
         run: make integration-k8s
+        timeout-minutes: 20  # Juju 4 may get stuck while destroying the test model
 
   integration-machine:
     runs-on: ubuntu-latest
@@ -83,6 +86,8 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-machine
       cancel-in-progress: true
+
+    continue-on-error: ${{ matrix.juju-channel == '4/beta' }}
 
     strategy:
       fail-fast: false
@@ -107,3 +112,4 @@ jobs:
 
       - name: Run integration tests
         run: make integration-machine
+        timeout-minutes: 20  # Juju 4 may get stuck while destroying the test model

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,16 +49,16 @@ jobs:
   integration-k8s:
     runs-on: ubuntu-latest
 
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-k8s
-      cancel-in-progress: true
-
-    continue-on-error: ${{ matrix.juju-channel == '4/beta' }}
-
     strategy:
       fail-fast: false
       matrix:
         juju-channel: ['3/stable', '4/beta']
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-k8s-${{ toJson(matrix) }}
+      cancel-in-progress: true
+
+    continue-on-error: ${{ matrix.juju-channel == '4/beta' }}
 
     steps:
       - name: Check out repo
@@ -83,16 +83,16 @@ jobs:
   integration-machine:
     runs-on: ubuntu-latest
 
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-machine
-      cancel-in-progress: true
-
-    continue-on-error: ${{ matrix.juju-channel == '4/beta' }}
-
     strategy:
       fail-fast: false
       matrix:
         juju-channel: ['3/stable', '4/beta']
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-machine-${{ toJson(matrix) }}
+      cancel-in-progress: true
+
+    continue-on-error: ${{ matrix.juju-channel == '4/beta' }}
 
     steps:
       - name: Check out repo


### PR DESCRIPTION
- adds matrix over Juju versions
- adds Juju channel 4/beta
- adds integration test timeout
- don't fail the overall job if 4/beta branch fails