### PR TITLE
docs: another wait() example, and link to it from ref and how-to

### DIFF
--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -267,6 +267,8 @@ juju.wait(
 )
 ```
 
+For more examples, see [Tutorial | Use a custom wait condition](#use_a_custom_wait_condition).
+
 
 ### Integrating two applications
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -1208,6 +1208,8 @@ class Juju:
                 error=jubilant.any_error,
             )
 
+        For more examples, see `Tutorial | Use a custom wait condition <https://documentation.ubuntu.com/jubilant/tutorial/getting-started/#use-a-custom-wait-condition>`_.
+
         Args:
             ready: Callable that takes a :class:`Status` object and returns true when the wait
                 should be considered ready. It needs to return true *successes* times in a row


### PR DESCRIPTION
Now that we have the tutorial (and how-to), there are actually quite a few examples of this, so this only adds one example. But it also shows how to use a stand-alone `def` function with type annotations (which can be better for autocompletion), and links to the examples from the `Juju.wait` reference docs and the migration how-to.

[**Preview**](https://canonical-ubuntu-documentation-library--195.com.readthedocs.build/jubilant/tutorial/getting-started/#use-a-custom-wait-condition)

Fixes #151.