### PR TITLE
ci: publish the jubilant-backports branch to the jubilant-backports PyPI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Because Jubilant-backports calls the Juju CLI, you'll also need to [install Juju
 To use Jubilant-backports in Python code:
 
 ```python
-import jubilant_backports as jubilant
+import jubilant
 
 juju = jubilant.Juju()
 juju.deploy('snappass-test')
@@ -35,7 +35,7 @@ Below is an example of a charm integration test. First we define a module-scoped
 
 ```python
 # conftest.py
-import jubilant_backports as jubilant
+import jubilant as jubilant
 
 @pytest.fixture(scope='module')
 def juju():
@@ -44,7 +44,7 @@ def juju():
 
 
 # test_deploy.py
-import jubilant_backports as jubilant
+import jubilant as jubilant
 
 def test_deploy(juju: jubilant.Juju):        # Use the "juju" fixture  # type: ignore
     juju.deploy('snappass-test')             # Deploy the charm
@@ -69,7 +69,7 @@ Jubilant-backports uses [`uv`](https://docs.astral.sh/uv/) to manage Python depe
 After that, clone the Jubilant codebase, check out the `jubilant-backports` branch, and use `make all` to run various checks and the unit tests:
 
 ```
-$ git clone https://github.com/tonyandrewmeyer/jubilant-backports
+$ git clone https://github.com/canonical/jubilant
 Cloning into 'jubilant-backports'...
 ...
 $ cd jubilant-backports

--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
-# Jubilant, the joyful library for integration-testing Juju charms
+# Jubilant-backports, the joyful library for integration-testing charms in Juju 2.9 and above
 
-Jubilant is a Python library that wraps the [Juju](https://juju.is/) CLI for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
+[Jubilant](https://canonical-jubilant.readthedocs-hosted.com) is a Python library that wraps the [Juju](https://juju.is/) CLI for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
 
-You should consider switching to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) (and they probably do). Jubilant has an API you'll pick up quickly, and it avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`. Read our [design goals](https://documentation.ubuntu.com/jubilant/explanation/design-goals).
+Jubilant-backports is a Python library that wraps Jubilant to provide support for running with Juju 2.9. It is a drop-in replacement for Jubilant, using the Jubilant package for Juju 3.0 and above, as well as when there are no differences between 2.9 and higher, and custom code otherwise.
 
-Jubilant 1.0.0 was released in April 2025. We'll avoid making breaking changes to the API after this point.
+You should consider using Jubilant-backports if you need to run the same charm integration test suite against Juju 2.9 as well as more modern Juju version.
 
-[**Read the full documentation**](https://documentation.ubuntu.com/jubilant/)
+## Using Jubilant-backports
 
-
-## Using Jubilant
-
-Jubilant is published to PyPI, so you can install and use it with your favorite Python package manager:
+Jubilant-backports is published to PyPI, so you can install and use it with your favorite Python package manager:
 
 ```
-$ pip install jubilant
+$ pip install jubilant-backports
 # or
-$ uv add jubilant
+$ uv add jubilant-backports
 ```
 
-Because Jubilant calls the Juju CLI, you'll also need to [install Juju](https://documentation.ubuntu.com/juju/3.6/howto/manage-juju/index.html#install-juju).
+Because Jubilant-backports calls the Juju CLI, you'll also need to [install Juju](https://documentation.ubuntu.com/juju/2.9/howto/manage-juju/index.html#install-juju).
 
-To use Jubilant in Python code:
+To use Jubilant-backports in Python code:
 
 ```python
-import jubilant
+import jubilant_backports as jubilant
 
 juju = jubilant.Juju()
 juju.deploy('snappass-test')
@@ -34,10 +31,12 @@ juju.wait(jubilant.all_active)
 juju.wait(lambda status: jubilant.all_active(status, 'snappass-test', 'another-app'))
 ```
 
-Below is an example of a charm integration test. First we define a module-scoped [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) named `juju` which creates a temporary model and runs the test with a `Juju` instance pointing at that model. Jubilant's`temp_model` context manager creates the model during test setup and destroys it during teardown:
+Below is an example of a charm integration test. First we define a module-scoped [pytest fixture](https://docs.pytest.org/en/stable/explanation/fixtures.html) named `juju` which creates a temporary model and runs the test with a `Juju` instance pointing at that model. Jubilant-backports's `temp_model` context manager creates the model during test setup and destroys it during teardown:
 
 ```python
 # conftest.py
+import jubilant_backports as jubilant
+
 @pytest.fixture(scope='module')
 def juju():
     with jubilant.temp_model() as juju:
@@ -45,7 +44,9 @@ def juju():
 
 
 # test_deploy.py
-def test_deploy(juju: jubilant.Juju):        # Use the "juju" fixture
+import jubilant_backports as jubilant
+
+def test_deploy(juju: jubilant.Juju):        # Use the "juju" fixture  # type: ignore
     juju.deploy('snappass-test')             # Deploy the charm
     status = juju.wait(jubilant.all_active)  # Wait till the app and unit are 'active'
 
@@ -56,35 +57,35 @@ def test_deploy(juju: jubilant.Juju):        # Use the "juju" fixture
     assert 'snappass' in response.text.lower()
 ```
 
-You don't have to use pytest with Jubilant, but it's what we recommend. Pytest's `assert`-based approach is a straight-forward way to write tests, and its fixtures are helpful for structuring setup and teardown.
+You don't have to use pytest with Jubilant-backports, but it's what we recommend. Pytest's `assert`-based approach is a straight-forward way to write tests, and its fixtures are helpful for structuring setup and teardown.
 
 
 ## Contributing and developing
 
-Anyone can contribute to Jubilant. It's best to start by [opening an issue](https://github.com/canonical/jubilant/issues) with a clear description of the problem or feature request, but you can also [open a pull request](https://github.com/canonical/jubilant/pulls) directly.
+Anyone can contribute to Jubilant-backports. The code lives in a [branch](https://github.com/canonical/jubilant/tree/jubilant-backports) of the regular [Jubilant](https://github.com/canonical/jubilant). It's best to start by [opening an issue](https://github.com/canonical/jubilant/issues) with a clear description of the problem or feature request, but you can also [open a pull request](https://github.com/canonical/jubilant/pulls) directly.
 
-Jubilant uses [`uv`](https://docs.astral.sh/uv/) to manage Python dependencies and tools, so you'll need to [install uv](https://docs.astral.sh/uv/#installation) to work on the library. You'll also need `make` to run local development tasks (but you probably have `make` installed already).
+Jubilant-backports uses [`uv`](https://docs.astral.sh/uv/) to manage Python dependencies and tools, so you'll need to [install uv](https://docs.astral.sh/uv/#installation) to work on the library. You'll also need `make` to run local development tasks (but you probably have `make` installed already).
 
-After that, clone the Jubilant codebase and use `make all` to run various checks and the unit tests:
+After that, clone the Jubilant codebase, check out the `jubilant-backports` branch, and use `make all` to run various checks and the unit tests:
 
 ```
-$ git clone https://github.com/canonical/jubilant
-Cloning into 'jubilant'...
+$ git clone https://github.com/tonyandrewmeyer/jubilant-backports
+Cloning into 'jubilant-backports'...
 ...
-$ cd jubilant
+$ cd jubilant-backports
+$ git checkout jubilant-backports
 $ make all
 ...
-========== 107 passed in 0.26s ==========
+========== 93 passed in 0.81s ==========
 ```
 
 To contribute a code change, write your fix or feature, add tests and docs, then run `make all` before you push and create a PR. Once you create a PR, GitHub will also run the integration tests, which takes several minutes.
 
-
 ## Doing a release
 
-To create a new release of Jubilant:
+To create a new release of Jubilant-backports:
 
 1. Update the `__version__` field in [`jubilant/__init__.py`](https://github.com/canonical/jubilant/blob/main/jubilant/__init__.py) to the new version you want to release.
 2. Push up a PR with this change and get it reviewed and merged.
 3. Create a [new release](https://github.com/canonical/jubilant/releases/new) on GitHub with good release notes. The tag should start with a `v`, like `v1.2.3`. Once you've created the release, the [`publish.yaml` workflow](https://github.com/canonical/jubilant/blob/main/.github/workflows/publish.yaml) will automatically publish it to PyPI.
-4. Once the publish workflow has finished, check that the new version appears in the [PyPI version history](https://pypi.org/project/jubilant/#history).
+4. Once the publish workflow has finished, check that the new version appears in the [PyPI version history](https://pypi.org/project/jubilant-backports/#history).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Below is an example of a charm integration test. First we define a module-scoped
 
 ```python
 # conftest.py
-import jubilant as jubilant
-
 @pytest.fixture(scope='module')
 def juju():
     with jubilant.temp_model() as juju:
@@ -44,8 +42,6 @@ def juju():
 
 
 # test_deploy.py
-import jubilant as jubilant
-
 def test_deploy(juju: jubilant.Juju):        # Use the "juju" fixture  # type: ignore
     juju.deploy('snappass-test')             # Deploy the charm
     status = juju.wait(jubilant.all_active)  # Wait till the app and unit are 'active'

--- a/docs/how-to/migrate-from-pytest-operator.md
+++ b/docs/how-to/migrate-from-pytest-operator.md
@@ -267,6 +267,8 @@ juju.wait(
 )
 ```
 
+For more examples, see [Tutorial | Use a custom wait condition](#use_a_custom_wait_condition).
+
 
 ### Integrating two applications
 

--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -47,4 +47,4 @@ __all__ = [
     'temp_model',
 ]
 
-__version__ = '1.4.0'
+__version__ = '1.0.0'

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -1208,6 +1208,8 @@ class Juju:
                 error=jubilant.any_error,
             )
 
+        For more examples, see `Tutorial | Use a custom wait condition <https://documentation.ubuntu.com/jubilant/tutorial/getting-started/#use-a-custom-wait-condition>`_.
+
         Args:
             ready: Callable that takes a :class:`Status` object and returns true when the wait
                 should be considered ready. It needs to return true *successes* times in a row

--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -1,4 +1,11 @@
-"""Dataclasses that contain parsed output from ``juju status --format=json``."""
+"""Dataclasses that contain parsed output from ``juju status --format=json``.
+
+These dataclasses were originally `generated from <https://github.com/juju/juju/compare/main...benhoyt:juju:status-dataclasses>`_
+the Go structs in the Juju codebase, to ensure they are correct. Class names
+come from the Go struct name, whereas attribute names come from the JSON field
+names. The one exception is that "Application" has been renamed to "App"
+throughout, for brevity (and "application" to "app").
+"""
 
 from __future__ import annotations
 
@@ -51,6 +58,8 @@ class FormattedBase:
 
 @dataclasses.dataclass(frozen=True)
 class StatusInfo:
+    """The main status class used for application, unit, and machine status."""
+
     current: str = ''
     message: str = ''
     reason: str = ''
@@ -89,6 +98,8 @@ class AppStatusRelation:
 
 @dataclasses.dataclass(frozen=True)
 class UnitStatus:
+    """Status of a single unit."""
+
     workload_status: StatusInfo = dataclasses.field(default_factory=StatusInfo)
     juju_status: StatusInfo = dataclasses.field(default_factory=StatusInfo)
     leader: bool = False
@@ -158,6 +169,8 @@ class UnitStatus:
 
 @dataclasses.dataclass(frozen=True)
 class AppStatus:
+    """Status of a single application."""
+
     charm: str
     charm_origin: str
     charm_name: str
@@ -257,6 +270,8 @@ class AppStatus:
 
 @dataclasses.dataclass(frozen=True)
 class EntityStatus:
+    """Status class used for storage status. See :class:`StatusInfo` for the main status class."""
+
     current: str = ''
     message: str = ''
     since: str = ''
@@ -474,6 +489,8 @@ class VolumeInfo:
 
 @dataclasses.dataclass(frozen=True)
 class CombinedStorage:
+    """Storage information."""
+
     storage: dict[str, StorageInfo] = dataclasses.field(default_factory=dict)  # type: ignore
     filesystems: dict[str, FilesystemInfo] = dataclasses.field(default_factory=dict)  # type: ignore
     volumes: dict[str, VolumeInfo] = dataclasses.field(default_factory=dict)  # type: ignore
@@ -501,6 +518,8 @@ class CombinedStorage:
 
 @dataclasses.dataclass(frozen=True)
 class ControllerStatus:
+    """Basic controller information."""
+
     timestamp: str = ''
 
     @classmethod
@@ -549,6 +568,8 @@ class NetworkInterface:
 
 @dataclasses.dataclass(frozen=True)
 class MachineStatus:
+    """Status of a single machine."""
+
     juju_status: StatusInfo = dataclasses.field(default_factory=StatusInfo)
     hostname: str = ''
     dns_name: str = ''
@@ -617,15 +638,31 @@ class MachineStatus:
 
 @dataclasses.dataclass(frozen=True)
 class ModelStatus:
+    """Status and basic information about the model."""
+
     name: str
+    """Name of model."""
+
     type: str
+    """Type of model, for example, ``caas`` for a Kubernetes model."""
+
     controller: str
+    """Name of controller."""
+
     cloud: str
+    """Name of cloud, for example ``aws`` or ``microk8s``."""
+
     version: str
+    """Juju agent version."""
 
     region: str = ''
+    """Cloud region."""
+
     upgrade_available: str = ''
+    """Version number if a new Juju agent is available."""
+
     model_status: StatusInfo = dataclasses.field(default_factory=StatusInfo)
+    """Status of the model. Normally the *current* field is ``available``."""
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> ModelStatus:
@@ -716,13 +753,25 @@ class Status:
     """Parsed version of the status object returned by ``juju status --format=json``."""
 
     model: ModelStatus
+    """Model information."""
+
     machines: dict[str, MachineStatus]
+    """Mapping of machine ID string (for example, ``"0"``) to machine information."""
+
     apps: dict[str, AppStatus]
+    """Mapping of application name to application information."""
 
     app_endpoints: dict[str, RemoteAppStatus] = dataclasses.field(default_factory=dict)  # type: ignore
+    """Mapping of offer name to remote application information."""
+
     offers: dict[str, OfferStatus] = dataclasses.field(default_factory=dict)  # type: ignore
+    """Mapping of offer name to offer information."""
+
     storage: CombinedStorage = dataclasses.field(default_factory=CombinedStorage)
+    """Storage information."""
+
     controller: ControllerStatus = dataclasses.field(default_factory=ControllerStatus)
+    """Controller information."""
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> Status:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "jubilant"
+name = "jubilant-backports"
 description = "Juju CLI wrapper for charm integration testing"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
The PR:
* Changes the project name (in this branch) to `jubilant-backports`
* Changes the version (in this branch) to `1.0.0` in preparation of the next release (the latest one from tonyandrewmeyer/jubilant-backports is 1.0.0a1).
* Adjusts the README to reflect the above.

Note that the only differences between the existing jubilant-backports and the current one, in terms of usage, are:
* Instead of `import jubilant_backports as jubilant` you just do `import jubilant`
* `Juju.cli_version` and `Juju.cli_major_version` have been removed.
* The status and task classes are exactly the same types as in `jubilant`, rather than having the same name but being a different class. If anyone was doing something like `jubilant.Status | jubilant_backports.Status` that's not required any more. This does mean that there are a couple of fields that will be empty in 2.9 (like "base") and some that will be empty in 3.x (like "series"), but the 3.x ones could already be empty.
* The `TaskError` class handles both `Task` and `ExecTask`, so `pytest.raises(TaskError)` works in 2.9 and 3.x.

This PR also includes d18f143693bd1db2523956f44c3072341dd97c21 and adab08c4a96c6f23493e847310fe94f145f4c3bf, because I started it from main@HEAD instead of the revision that the branch came from. I've opened https://github.com/canonical/jubilant/pull/198 to do that separately and will rebase when that's merged.