### PR TITLE
fix: allow revealed secrets without checksums

### DIFF
--- a/jubilant/secrettypes.py
+++ b/jubilant/secrettypes.py
@@ -75,7 +75,9 @@ class RevealedSecret(Secret):
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> RevealedSecret:
         kwargs = dataclasses.asdict(super()._from_dict(d))
-        return RevealedSecret(content=d['content']['Data'], checksum=d['checksum'], **kwargs)
+        return RevealedSecret(
+            content=d['content']['Data'], checksum=d.get('checksum', ''), **kwargs
+        )
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
A secret object doesn't have a `checksum` field in older versions of Juju (3.0 ~ 3.5).

This change uses an empty string for a secret in such cases.