### PR TITLE
docs: use 'integration' group in CI example

### DIFF
--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -194,7 +194,7 @@ We recommend using [concierge](https://github.com/jnsgruk/concierge/) to set up 
 - name: Run integration tests
   run: |
       charmcraft pack
-      uv run pytest tests/integration -vv --log-level=INFO
+      uv run --group integration pytest tests/integration -vv --log-level=INFO
 ```
 
 


### PR DESCRIPTION
Since we recommend that charms have a dependency group called `integration`, how about specifying this group in the CI example in the tutorial?