### PR TITLE
feat: add SecretURI.__repr__ to make type obvious in error messages

### DIFF
--- a/jubilant/secrettypes.py
+++ b/jubilant/secrettypes.py
@@ -10,6 +10,10 @@ from typing import Any
 class SecretURI(str):
     """A string subclass that represents a secret URI ("secret:...")."""
 
+    def __repr__(self):
+        """Override to make the type obvious in error messages."""
+        return f'SecretURI({super().__repr__()})'
+
     @property
     def unique_identifier(self) -> str:
         """Unique identifier of this secret URI.

--- a/tests/unit/test_secret_uri.py
+++ b/tests/unit/test_secret_uri.py
@@ -7,6 +7,11 @@ def test_str():
     assert uri == 'abc'
 
 
+def test_repr():
+    uri = jubilant.SecretURI('xyz')
+    assert repr(uri) == "SecretURI('xyz')"
+
+
 def test_unique_identifier():
     assert jubilant.SecretURI('abc').unique_identifier == 'abc'
     assert jubilant.SecretURI('secret:xyz').unique_identifier == 'xyz'


### PR DESCRIPTION
See rationale in #211.