### PR TITLE
docs: Jubilant is not *just* for charm integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Jubilant, the joyful library for integration-testing Juju charms
+# Jubilant, the joyful library for driving Juju
 
-Jubilant is a Python library that wraps the [Juju](https://juju.is/) CLI for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
+Jubilant is a Python library that wraps the [Juju](https://juju.is/) CLI, primarily for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
 
 You should consider switching to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) (and they probably do). Jubilant has an API you'll pick up quickly, and it avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`. Read our [design goals](https://documentation.ubuntu.com/jubilant/explanation/design-goals).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ reference/index
 explanation/index
 ```
 
-Jubilant is a Python library that wraps the [Juju](https://juju.is/) CLI for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
+Jubilant is a Python library that wraps the [Juju](https://juju.is/) CLI, primarily for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
 
 You should consider switching to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) (and they probably do). Jubilant has an API you'll pick up quickly, and it avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`. Read our [design goals](explanation/design-goals).
 

--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -1,4 +1,4 @@
-"""Jubilant is a Pythonic wrapper around the Juju CLI for writing charm integration tests."""
+"""Jubilant is a Pythonic wrapper around the Juju CLI."""
 
 from . import secrettypes, statustypes
 from ._all_any import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jubilant"
-description = "Juju CLI wrapper for charm integration testing"
+description = "Juju CLI wrapper, primarily for charm integration testing"
 readme = "README.md"
 requires-python = ">=3.8"
 dynamic = ["version"]


### PR DESCRIPTION
Currently the docs indicate Jubilant is just for charm integration tests. Downplay that a bit: it's *primarily* for that, but not solely.

Fixes #191