### PR TITLE
fix: fix Version.__str__ and strictify parsing

### DIFF
--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -35,8 +35,10 @@ def test_simple(run: mocks.Run):
             '3.6.11-genericlinux-amd64',
             jubilant.Version(3, 6, 11, release='genericlinux', arch='amd64'),
         ),
-        ('3.1-rel-arch', jubilant.Version(3, 1, 0, release='rel', arch='arch')),
-        ('1.2-rel-arch', jubilant.Version(1, 2, 0, release='rel', arch='arch')),
+        (
+            '4.0.0-genericlinux-amd64',
+            jubilant.Version(4, 0, 0, release='genericlinux', arch='amd64'),
+        ),
         ('2.3.4-rel-arch', jubilant.Version(2, 3, 4, release='rel', arch='arch')),
         ('3.4.5.6-rel-arch', jubilant.Version(3, 4, 5, build=6, release='rel', arch='arch')),
         ('4.5-beta6-rel-arch', jubilant.Version(4, 5, 6, tag='beta', release='rel', arch='arch')),


### PR DESCRIPTION
Currently '4.0.0-genericlinux-amd64' parsed and str'd gives '4.0-genericlinux-amd64', which isn't correct (and not what Juju's `semversion.Number.String` does). So fix that.

In addition, switch to Juju's "strict" parsing, which is what Juju's semversion.Parse does by default. Specifically, this means that "1.2-release-arch" is not supported. I think this is the right thing to do here.