### PR TITLE
feat: provide additional arguments for model destruction

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -623,6 +623,9 @@ class Juju:
         *,
         destroy_storage: bool = False,
         force: bool = False,
+        no_wait: bool = False,
+        release_storage: bool = False,
+        timeout: float | None = None,
     ) -> None:
         """Terminate all machines (or containers) and resources for a model.
 
@@ -631,14 +634,26 @@ class Juju:
 
         Args:
             model: Name of model to destroy.
-            destroy_storage: If true, destroy all storage instances in the model.
-            force: If true, force model destruction and ignore any errors.
+            destroy_storage: If True, destroy all storage instances in the model.
+            force: If True, force model destruction and ignore any errors.
+            no_wait: If True, rush through model destruction without waiting for each step
+                to complete.
+            release_storage: If True, release all storage instances in the model.
+                This is mutually exclusive with *destroy_storage*.
+            timeout: Maximum time (in seconds) to wait for each step in the model destruction.
+                This option can only be used with *force*.
         """
         args = ['destroy-model', model, '--no-prompt']
         if destroy_storage:
             args.append('--destroy-storage')
         if force:
             args.append('--force')
+        if no_wait:
+            args.append('--no-wait')
+        if release_storage:
+            args.append('--release-storage')
+        if timeout is not None:
+            args.extend(['--timeout', f'{timeout}s'])
         self.cli(*args, include_model=False)
         if model == self.model:
             self.model = None

--- a/jubilant/_test_helpers.py
+++ b/jubilant/_test_helpers.py
@@ -57,8 +57,8 @@ def temp_model(
         if not keep:
             assert juju.model is not None
             try:
-                # We're not using juju.destroy_model() here, as it doesn't have a timeout
-                # parameter. If we add such a parameter, we can update this.
+                # We're not using juju.destroy_model() here, as Juju doesn't provide a way
+                # to specify the timeout for the entire model destruction operation.
                 args = ['destroy-model', juju.model, '--no-prompt', '--destroy-storage', '--force']
                 juju._cli(*args, include_model=False, timeout=10 * 60)
                 juju.model = None

--- a/tests/unit/test_destroy_model.py
+++ b/tests/unit/test_destroy_model.py
@@ -21,10 +21,46 @@ def test_destroy_other(run: mocks.Run):
     assert juju.model == 'initial'
 
 
-def test_args(run: mocks.Run):
-    run.handle(['juju', 'destroy-model', 'bad', '--no-prompt', '--destroy-storage', '--force'])
+def test_destroy_with_destroy_storage(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'xyz', '--no-prompt', '--destroy-storage'])
     juju = jubilant.Juju()
 
-    juju.destroy_model('bad', destroy_storage=True, force=True)
+    juju.destroy_model('xyz', destroy_storage=True)
+
+    assert juju.model is None
+
+
+def test_destroy_with_force(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'xyz', '--no-prompt', '--force'])
+    juju = jubilant.Juju()
+
+    juju.destroy_model('xyz', force=True)
+
+    assert juju.model is None
+
+
+def test_destroy_with_no_wait(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'xyz', '--no-prompt', '--no-wait'])
+    juju = jubilant.Juju()
+
+    juju.destroy_model('xyz', no_wait=True)
+
+    assert juju.model is None
+
+
+def test_destroy_with_release_storage(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'xyz', '--no-prompt', '--release-storage'])
+    juju = jubilant.Juju()
+
+    juju.destroy_model('xyz', release_storage=True)
+
+    assert juju.model is None
+
+
+def test_destroy_with_timeout(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'xyz', '--no-prompt', '--force', '--timeout', '120s'])
+    juju = jubilant.Juju()
+
+    juju.destroy_model('xyz', force=True, timeout=120)
 
     assert juju.model is None


### PR DESCRIPTION
This pull request adds the `release_storage`, `timeout`, and `no_wait` to the `destroy-model` method.

Fixes #239