### PR TITLE
chore: declare pytest.mark.machine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,9 @@ reportPrivateUsage = false  # silence errors about use of _from_dict outside cla
 reportUnnecessaryTypeIgnoreComment = "error"
 
 [tool.pytest.ini_options]
+markers = [
+  "machine: integration tests that require a Juju machine model",
+]
 pythonpath = [
   "."
 ]


### PR DESCRIPTION
Without the declaration, we get a warning in CI:

```
tests/integration/test_machine.py:14
  /home/runner/work/jubilant/jubilant/tests/integration/test_machine.py:14: PytestUnknownMarkWarning: Unknown pytest.mark.machine - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    pytestmark = pytest.mark.machine
```