### PR TITLE
refactor: add the ssh key earlier, so that no retry is needed

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -28,6 +28,12 @@ def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju]:
 
 
 @pytest.fixture(scope='module')
+def juju_version(juju: jubilant.Juju) -> jubilant.Version:
+    """Module-scoped pytest fixture that returns the Juju CLI version."""
+    return juju.version()
+
+
+@pytest.fixture(scope='module')
 def model2(request: pytest.FixtureRequest) -> Generator[jubilant.Juju]:
     """Module-scoped pytest fixture that creates a (second) temporary model."""
     keep_models = cast(bool, request.config.getoption('--keep-models'))

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -76,22 +76,32 @@ def test_run_unit_not_found(juju: jubilant.Juju):
         juju.run('testdb/42', 'do-thing')
 
 
-def test_exec_success(juju: jubilant.Juju):
+def test_exec_success(juju: jubilant.Juju, juju_version: jubilant.Version):
     task = juju.exec('echo foo', unit='testdb/0')
     assert task.success
     assert task.return_code == 0
-    assert task.stdout == 'foo\n'
+    # Juju 4.0.2 and 4.0.3 strip newlines from exec stdout.
+    expected_foo = 'foo\n'
+    expected_bar_baz = 'bar baz\n'
+    if juju_version.major == 4:
+        expected_foo = expected_foo.rstrip('\n')
+        expected_bar_baz = expected_bar_baz.rstrip('\n')
+    assert task.stdout == expected_foo
     assert task.stderr == ''
 
     task = juju.exec('echo', 'bar', 'baz', unit='testdb/0')
     assert task.success
-    assert task.stdout == 'bar baz\n'
+    assert task.stdout == expected_bar_baz
 
 
-def test_exec_leader(juju: jubilant.Juju):
+def test_exec_leader(juju: jubilant.Juju, juju_version: jubilant.Version):
     task = juju.exec('echo foo', unit='testdb/leader')
     assert task.success
-    assert task.stdout == 'foo\n'
+    # Juju 4.0.2 and 4.0.3 strip newlines from exec stdout.
+    expected = 'foo\n'
+    if juju_version.major == 4:
+        expected = expected.rstrip('\n')
+    assert task.stdout == expected
 
 
 def test_exec_error(juju: jubilant.Juju):

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -36,16 +36,22 @@ def setup(juju: jubilant.Juju, private_key_file: str):
     juju.wait(jubilant.all_active)
 
 
-def test_exec(juju: jubilant.Juju):
+def test_exec(juju: jubilant.Juju, juju_version: jubilant.Version):
     task = juju.exec('echo foo', machine=0)
     assert task.success
     assert task.return_code == 0
-    assert task.stdout == 'foo\n'
+    # Juju 4.0.2 and 4.0.3 strip newlines from exec stdout.
+    expected_foo = 'foo\n'
+    expected_bar_baz = 'bar baz\n'
+    if juju_version.major == 4:
+        expected_foo = expected_foo.rstrip('\n')
+        expected_bar_baz = expected_bar_baz.rstrip('\n')
+    assert task.stdout == expected_foo
     assert task.stderr == ''
 
     task = juju.exec('echo', 'bar', 'baz', machine=0)
     assert task.success
-    assert task.stdout == 'bar baz\n'
+    assert task.stdout == expected_bar_baz
 
 
 def test_ssh(juju: jubilant.Juju, private_key_file: str):


### PR DESCRIPTION
In https://github.com/juju/juju/issues/21425#issuecomment-3998249626, Heather explains that if we add the SSH key to the model before deploying any application, the key will be there when the application is deployed.

This PR rearranges the machine integration tests slightly so that the SSH key is added earlier, and removes the retrying in the SSH test. It does mean the key is available for other tests, but it's just ignored so that should be fine.

The PR also works around a [Juju bug](https://github.com/juju/juju/issues/21927) where exec stdout has newlines trimmed. The tests will break when the Juju bug is fixed, so we will know that the workaround should be removed.