### PR TITLE
feat: enhance status method to accept optional selectors for filtering

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -1324,9 +1324,35 @@ class Juju:
 
         return self.cli(*cli_args)
 
-    def status(self) -> Status:
-        """Fetch the status of the current model, including its applications and units."""
-        stdout = self.cli('status', '--format', 'json')
+    def status(self, *selectors: str) -> Status:
+        """Fetch the status of the current model, including its applications and units.
+
+        Example::
+
+            juju = jubilant.Juju()
+
+            # Get status for all applications and units:
+            print(juju.status())
+
+            # Get status for specific machines, applications, or units:
+            print(juju.status('0'))
+            print(juju.status('myapp'))
+            print(juju.status('myapp/0'))
+            print(juju.status('myapp1', 'myapp2'))
+            print(juju.status('0', 'myapp1', 'myapp2/1'))
+
+            # Get status for specific workload status values:
+            print(juju.status('active'))
+            print(juju.status('blocked', 'error'))
+
+        Args:
+            selectors: Optional status selectors (machines, applications, units, or status
+                values).
+        """
+        args = ['status', '--format', 'json']
+        if selectors:
+            args.extend(selectors)
+        stdout = self.cli(*args)
         result = json.loads(stdout)
         return Status._from_dict(result)
 

--- a/tests/integration/test_relations.py
+++ b/tests/integration/test_relations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import jubilant
 
 from . import helpers
@@ -22,3 +24,32 @@ def test_integrate_and_remove_relation(juju: jubilant.Juju):
             not status.apps['testdb'].relations and not status.apps['testapp'].relations
         )
     )
+
+
+def test_status_with_selectors(juju: jubilant.Juju):
+    juju.wait(jubilant.all_active)
+
+    try:
+        status_testdb = juju.status('testdb')
+    except jubilant.CLIError as exc:
+        if 'patterns are not implemented' in str(exc).lower():
+            pytest.skip('status selectors are not supported by this Juju client/server pair')
+        raise
+
+    assert 'testdb' in status_testdb.apps
+    assert 'testapp' not in status_testdb.apps
+
+    status_testapp = juju.status('testapp')
+    assert 'testapp' in status_testapp.apps
+    assert 'testdb' not in status_testapp.apps
+
+    status_unit = juju.status('testdb/0')
+    assert 'testdb' in status_unit.apps
+    assert 'testdb/0' in status_unit.apps['testdb'].units
+    assert 'testapp' not in status_unit.apps
+
+    status_active = juju.status('active')
+    assert status_active.apps
+
+    status_error = juju.status('error')
+    assert not status_error.apps

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -4,7 +4,7 @@ import jubilant
 from jubilant import statustypes
 
 from . import mocks
-from .fake_statuses import MINIMAL_JSON, MINIMAL_STATUS, SNAPPASS_JSON
+from .fake_statuses import DATABASE_WEBAPP_JSON, MINIMAL_JSON, MINIMAL_STATUS, SNAPPASS_JSON
 
 
 def test_minimal(run: mocks.Run):
@@ -35,6 +35,29 @@ def test_real_status(run: mocks.Run):
     assert status.apps['snappass-test'].is_active
     assert status.apps['snappass-test'].units['snappass-test/0'].is_active
     assert status.apps['snappass-test'].units['snappass-test/0'].leader
+
+
+def test_status_with_single_selector(run: mocks.Run):
+    run.handle(['juju', 'status', '--format', 'json', 'snappass-test'], stdout=SNAPPASS_JSON)
+    juju = jubilant.Juju()
+
+    status = juju.status('snappass-test')
+
+    assert status.model.type == 'caas'
+    assert status.apps['snappass-test'].is_active
+
+
+def test_status_with_multiple_selectors(run: mocks.Run):
+    run.handle(
+        ['juju', 'status', '--format', 'json', 'database', 'webapp/0'],
+        stdout=DATABASE_WEBAPP_JSON,
+    )
+    juju = jubilant.Juju()
+
+    status = juju.status('database', 'webapp/0')
+
+    assert status.apps['database'].is_active
+    assert status.apps['webapp'].is_active
 
 
 def test_status_eq():


### PR DESCRIPTION
Add support for optional selectors to `Juju.status`, matching the `<selector>` arguments in the `juju status [options] [<selector> [...]]` CLI command.

```python
Juju.status("myapp1", "myapp2", "myapp3")
```
is equivalent to
```bash
juju status --format json myapp1 myapp2 myapp3
```

Fixes #249 