### PR TITLE
test: don't rely on Juju.secrets() order

### DIFF
--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -33,7 +33,7 @@ def test_update_secret(juju: jubilant.Juju):
 
 
 def test_get_all_secrets(juju: jubilant.Juju):
-    secrets = sorted(juju.secrets(), key=lambda s: s.name)
+    secrets = sorted(juju.secrets(), key=lambda s: s.name or s.uri)
     assert len(secrets) == 2
 
     assert secrets[0].revision == 1


### PR DESCRIPTION
I don't know if `juju secrets` output was ever intended to be in a stable order.
I guess we got stable order before, because this test somehow worked so far.
Now it's failing in an unrelated PR: https://github.com/canonical/jubilant/actions/runs/23633104321/job/68836635117?pr=276