### PR TITLE
feat: implement add_cloud and update_cloud methods

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -106,6 +106,82 @@ class Juju:
     # about where to put each new method.
 
     @overload
+    def add_cloud(
+        self,
+        cloud: str,
+        definition: str | pathlib.Path | Mapping[str, Any],
+        *,
+        client: Literal[True],
+        controller: str | None = None,
+        credential: str | None = None,
+        force: bool = False,
+        target_controller: str | None = None,
+    ) -> None: ...
+
+    @overload
+    def add_cloud(
+        self,
+        cloud: str,
+        definition: str | pathlib.Path | Mapping[str, Any],
+        *,
+        client: bool = False,
+        controller: str,
+        credential: str | None = None,
+        force: bool = False,
+        target_controller: str | None = None,
+    ) -> None: ...
+
+    def add_cloud(
+        self,
+        cloud: str,
+        definition: str | pathlib.Path | Mapping[str, Any],
+        *,
+        client: bool = False,
+        controller: str | None = None,
+        credential: str | None = None,
+        force: bool = False,
+        target_controller: str | None = None,
+    ) -> None:
+        """Add a cloud definition to a controller or to a client (or both).
+
+        Args:
+            cloud: Name for the cloud.
+            definition: A YAML file or a mapping containing the cloud definition.
+            client: If true, save the cloud to the client for use with future controllers.
+                You must specify ``client=True`` or provide *controller* (or both).
+            controller: If specified, save the cloud to the named controller.
+            credential: Credential to use for the new cloud.
+            force: If true, force add cloud to the controller, bypassing checks.
+            target_controller: Name of a JAAS managed controller to add the cloud to.
+        """
+        if not client and controller is None:
+            raise TypeError('"client" must be true or "controller" must be specified (or both)')
+
+        args = ['add-cloud', cloud]
+
+        if client:
+            args.append('--client')
+        if controller is not None:
+            args.extend(['--controller', controller])
+        if credential is not None:
+            args.extend(['--credential', credential])
+        if force:
+            args.append('--force')
+        if target_controller is not None:
+            args.extend(['--target-controller', target_controller])
+
+        if isinstance(definition, (str, pathlib.Path)):
+            with self._path_for_juju(definition) as definition_path:
+                args.extend(['--file', definition_path])
+                self.cli(*args, include_model=False)
+        else:
+            with tempfile.NamedTemporaryFile('w+', dir=self._temp_dir) as temp_file:
+                _yaml.safe_dump(definition, temp_file)
+                temp_file.flush()
+                args.extend(['--file', temp_file.name])
+                self.cli(*args, include_model=False)
+
+    @overload
     def add_credential(
         self,
         cloud: str,
@@ -1349,6 +1425,66 @@ class Juju:
 
         self.cli(*args)
 
+    @overload
+    def update_cloud(
+        self,
+        cloud: str,
+        definition: str | pathlib.Path | Mapping[str, Any],
+        *,
+        client: Literal[True],
+        controller: str | None = None,
+    ) -> None: ...
+
+    @overload
+    def update_cloud(
+        self,
+        cloud: str,
+        definition: str | pathlib.Path | Mapping[str, Any],
+        *,
+        client: bool = False,
+        controller: str,
+    ) -> None: ...
+
+    def update_cloud(
+        self,
+        cloud: str,
+        definition: str | pathlib.Path | Mapping[str, Any],
+        *,
+        client: bool = False,
+        controller: str | None = None,
+    ) -> None:
+        """Update cloud information on this client or on a controller (or both).
+
+        Args:
+            cloud: Name of the cloud to update.
+            definition: A YAML file or a mapping containing the cloud definition.
+            client: If true, update the cloud definition on this client. You must specify
+                ``client=True`` or provide *controller* (or both).
+            controller: If specified, update the cloud definition on the named controller.
+        """
+        if not client and controller is None:
+            raise TypeError('"client" must be true or "controller" must be specified (or both)')
+
+        args = ['update-cloud', cloud]
+
+        if client:
+            args.append('--client')
+        if controller is not None:
+            args.extend(['--controller', controller])
+
+        if isinstance(definition, (str, pathlib.Path)):
+            # Use -f instead of --file; juju update-cloud only supports the short form.
+            # See: https://github.com/juju/juju/blob/main/cmd/juju/cloud/updatecloud.go
+            with self._path_for_juju(definition) as definition_path:
+                args.extend(['-f', definition_path])
+                self.cli(*args, include_model=False)
+        else:
+            with tempfile.NamedTemporaryFile('w+', dir=self._temp_dir) as temp_file:
+                _yaml.safe_dump(definition, temp_file)
+                temp_file.flush()
+                args.extend(['-f', temp_file.name])
+                self.cli(*args, include_model=False)
+
     def update_secret(
         self,
         identifier: str | SecretURI,
@@ -1493,6 +1629,19 @@ class Juju:
             return temp_dir
         else:
             return tempfile.gettempdir()
+
+    @contextlib.contextmanager
+    def _path_for_juju(self, path: str | pathlib.Path) -> Generator[str]:
+        """Yield a path Juju can access, copying into a snap-safe temp dir if needed."""
+        path = str(path)
+        if not self._juju_is_snap:
+            yield path
+            return
+
+        with tempfile.TemporaryDirectory(dir=self._temp_dir) as temp_dir:
+            temp = os.path.join(temp_dir, os.path.basename(path))
+            shutil.copy(path, temp)
+            yield temp
 
     # This context manager is for deploy() and refresh(), and automatically copies
     # a local charm file and local resource files into a temporary directory if Juju

--- a/tests/integration/test_cloud.py
+++ b/tests/integration/test_cloud.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import jubilant
+
+
+def test_add_and_update_cloud_client(juju: jubilant.Juju):
+    cloud_name = 'it-cloud-client'
+
+    original_endpoint = 'https://fake-endpoint-add.local:5000/v3'
+    updated_endpoint = 'https://fake-endpoint-update.local:5000/v3'
+
+    original_definition = {
+        'clouds': {
+            cloud_name: {
+                'type': 'openstack',
+                'auth-types': ['userpass'],
+                'regions': {'dev-region': {'endpoint': original_endpoint}},
+            }
+        }
+    }
+
+    updated_definition = {
+        'clouds': {
+            cloud_name: {
+                'type': 'openstack',
+                'auth-types': ['userpass'],
+                'regions': {'dev-region': {'endpoint': updated_endpoint}},
+            }
+        }
+    }
+
+    juju.add_cloud(cloud_name, original_definition, client=True)
+
+    try:
+        show_cloud = juju.cli('show-cloud', '--client', cloud_name, include_model=False)
+        assert original_endpoint in show_cloud
+
+        juju.update_cloud(cloud_name, updated_definition, client=True)
+        show_cloud = juju.cli('show-cloud', '--client', cloud_name, include_model=False)
+        assert updated_endpoint in show_cloud
+    finally:
+        juju.cli('remove-cloud', '--client', cloud_name, include_model=False)
+
+
+def test_add_and_update_cloud_controller(juju: jubilant.Juju):
+    controller = juju.show_model().controller_name
+    cloud_name = 'it-cloud-controller'
+
+    original_endpoint = 'https://fake-endpoint-add-ctrl.local:5000/v3'
+    updated_endpoint = 'https://fake-endpoint-update-ctrl.local:5000/v3'
+
+    original_definition = {
+        'clouds': {
+            cloud_name: {
+                'type': 'openstack',
+                'auth-types': ['userpass'],
+                'regions': {'dev-region': {'endpoint': original_endpoint}},
+            }
+        }
+    }
+
+    updated_definition = {
+        'clouds': {
+            cloud_name: {
+                'type': 'openstack',
+                'auth-types': ['userpass'],
+                'regions': {'dev-region': {'endpoint': updated_endpoint}},
+            }
+        }
+    }
+
+    juju.add_cloud(cloud_name, original_definition, controller=controller)
+
+    try:
+        show_cloud = juju.cli(
+            'show-cloud', '--controller', controller, cloud_name, include_model=False
+        )
+        assert original_endpoint in show_cloud
+
+        juju.update_cloud(cloud_name, updated_definition, controller=controller)
+        show_cloud = juju.cli(
+            'show-cloud', '--controller', controller, cloud_name, include_model=False
+        )
+        assert updated_endpoint in show_cloud
+    finally:
+        juju.cli('remove-cloud', '--controller', controller, cloud_name, include_model=False)

--- a/tests/unit/test_add_cloud.py
+++ b/tests/unit/test_add_cloud.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import jubilant
+
+from . import mocks
+
+
+def test_with_path_str(run: mocks.Run):
+    run.handle(['juju', 'add-cloud', 'mycloud', '--client', '--file', '/path/to/cloud.yaml'])
+    juju = jubilant.Juju()
+
+    juju.add_cloud('mycloud', '/path/to/cloud.yaml', client=True)
+
+
+def test_with_controller_default_client(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'add-cloud',
+            'mycloud',
+            '--controller',
+            'mycontroller',
+            '--file',
+            '/path/to/cloud.yaml',
+        ]
+    )
+    juju = jubilant.Juju()
+
+    juju.add_cloud('mycloud', '/path/to/cloud.yaml', controller='mycontroller')
+
+
+def test_with_path_pathlib(run: mocks.Run):
+    run.handle(['juju', 'add-cloud', 'mycloud', '--client', '--file', '/path/to/cloud.yaml'])
+    juju = jubilant.Juju()
+
+    juju.add_cloud('mycloud', pathlib.Path('/path/to/cloud.yaml'), client=True)
+
+
+def test_with_yaml_dict(run: mocks.Run, mock_file: mocks.NamedTemporaryFile):
+    run.handle(['juju', 'add-cloud', 'mycloud', '--client', '--file', mock_file.name])
+    juju = jubilant.Juju()
+
+    definition = {'clouds': {'mycloud': {'type': 'lxd', 'endpoint': '1.2.3.4'}}}
+    juju.add_cloud('mycloud', definition, client=True)
+
+    assert len(mock_file.writes) == 1
+    assert 'type: lxd' in mock_file.writes[0]
+
+
+def test_all_args(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'add-cloud',
+            'mycloud',
+            '--client',
+            '--controller',
+            'mycontroller',
+            '--credential',
+            'mycred',
+            '--force',
+            '--target-controller',
+            'target-ctrl',
+            '--file',
+            '/path/to/cloud.yaml',
+        ]
+    )
+    juju = jubilant.Juju()
+
+    juju.add_cloud(
+        'mycloud',
+        '/path/to/cloud.yaml',
+        client=True,
+        controller='mycontroller',
+        credential='mycred',
+        force=True,
+        target_controller='target-ctrl',
+    )
+
+
+def test_requires_client_or_controller():
+    juju = jubilant.Juju()
+
+    with pytest.raises(TypeError):
+        juju.add_cloud('mycloud', '/path/to/cloud.yaml')  # type: ignore

--- a/tests/unit/test_update_cloud.py
+++ b/tests/unit/test_update_cloud.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import jubilant
+
+from . import mocks
+
+
+def test_with_path_str(run: mocks.Run):
+    run.handle(['juju', 'update-cloud', 'mycloud', '--client', '-f', '/path/to/cloud.yaml'])
+    juju = jubilant.Juju()
+
+    juju.update_cloud('mycloud', '/path/to/cloud.yaml', client=True)
+
+
+def test_with_controller_default_client(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'update-cloud',
+            'mycloud',
+            '--controller',
+            'mycontroller',
+            '-f',
+            '/path/to/cloud.yaml',
+        ]
+    )
+    juju = jubilant.Juju()
+
+    juju.update_cloud('mycloud', '/path/to/cloud.yaml', controller='mycontroller')
+
+
+def test_with_path_pathlib(run: mocks.Run):
+    run.handle(['juju', 'update-cloud', 'mycloud', '--client', '-f', '/path/to/cloud.yaml'])
+    juju = jubilant.Juju()
+
+    juju.update_cloud('mycloud', pathlib.Path('/path/to/cloud.yaml'), client=True)
+
+
+def test_with_yaml_dict(run: mocks.Run, mock_file: mocks.NamedTemporaryFile):
+    run.handle(['juju', 'update-cloud', 'mycloud', '--client', '-f', mock_file.name])
+    juju = jubilant.Juju()
+
+    definition = {'clouds': {'mycloud': {'type': 'lxd', 'endpoint': '1.2.3.4'}}}
+    juju.update_cloud('mycloud', definition, client=True)
+
+    assert len(mock_file.writes) == 1
+    assert 'type: lxd' in mock_file.writes[0]
+
+
+def test_all_args(run: mocks.Run):
+    run.handle(
+        [
+            'juju',
+            'update-cloud',
+            'mycloud',
+            '--client',
+            '--controller',
+            'mycontroller',
+            '-f',
+            '/path/to/cloud.yaml',
+        ]
+    )
+    juju = jubilant.Juju()
+
+    juju.update_cloud(
+        'mycloud',
+        '/path/to/cloud.yaml',
+        client=True,
+        controller='mycontroller',
+    )
+
+
+def test_requires_client_or_controller():
+    juju = jubilant.Juju()
+
+    with pytest.raises(TypeError):
+        juju.update_cloud('mycloud', '/path/to/cloud.yaml')  # type: ignore


### PR DESCRIPTION
Add support for `add_cloud` and `update_cloud` methods in the `Juju` class, in line with the `juju add-cloud/update-cloud` commands.

Fixes #156