### PR TITLE
docs: restructure homepage and update intro to Jubilant

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ You should switch to Jubilant if your integration tests currently use [pytest-op
 
 ## In this documentation
 
-- [Getting started with Jubilant](tutorial/getting-started)
+- [Tutorial: Getting started with Jubilant](tutorial/getting-started)
 - [Design goals](explanation/design-goals)
 - [API reference](reference/jubilant)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,3 @@
----
-relatedlinks: "[Charmcraft](https://documentation.ubuntu.com/charmcraft/stable/), [Charmlibs](https://documentation.ubuntu.com/charmlibs/), [Concierge](https://github.com/canonical/concierge), [Juju](https://documentation.ubuntu.com/juju/3.6/), [Ops](https://documentation.ubuntu.com/ops/latest/), [Pebble](https://documentation.ubuntu.com/pebble/)"
----
-
 # Jubilant
 
 ```{toctree}
@@ -13,46 +9,30 @@ reference/index
 explanation/index
 ```
 
-Jubilant is a Python library that wraps the [Juju](https://canonical.com/juju) CLI, primarily for use in charm integration tests. It provides methods that map 1:1 to Juju CLI commands, but with a type-annotated, Pythonic interface.
+Jubilant is a Python library that wraps the [Juju](https://canonical.com/juju) CLI, primarily for use in charm integration tests.
 
-You should consider switching to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator) (and they probably do). Jubilant has an API you'll pick up quickly, and it avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`. Read our [design goals](explanation/design-goals).
+When writing charm integration tests, use Jubilant with `pytest-jubilant`. See {external+operator:ref}`How to write integration tests for a charm <write-integration-tests-for-a-charm>` in the Ops documentation. Ops also has several [demo charms](https://github.com/canonical/operator/tree/main/examples) that you can experiment with. The demo charms use Jubilant in their integration tests.
 
-Jubilant 1.0.0 was released in April 2025. We will avoid making breaking changes to the API after this point.
-
-
-The library provides:
+Jubilant's methods map 1:1 to Juju CLI commands and have a type-annotated, Pythonic interface:
 
 - The main [](jubilant.Juju) class, with methods such as [`deploy`](jubilant.Juju.deploy) and [`integrate`](jubilant.Juju.integrate)
 - The [`Juju.wait`](jubilant.Juju.wait) method, which waits for a condition such as "all apps active"
 - Status helpers such as [](jubilant.all_active), for use with `Juju.wait`
 - Context managers such as [](jubilant.temp_model), for use in test setup and teardown
 
+You should switch to Jubilant if your integration tests currently use [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator). Jubilant avoids some of the pain points of [python-libjuju](https://github.com/juju/python-libjuju/), such as websocket failures and having to use `async`.
 
 ## In this documentation
 
-````{grid} 1 1 2 2
-```{grid-item-card} [Tutorial](tutorial/getting-started)
-**Start here**: a hands-on introduction to Jubilant
-```
-
-```{grid-item-card} [Reference](reference/index)
-**Technical information**
-- [API reference](reference/jubilant)
-```
-````
-
-````{grid} 1 1 2 2
-```{grid-item-card} [Explanation](explanation/index)
-**Discussion and clarification** of key topics
+- [Getting started with Jubilant](tutorial/getting-started)
 - [Design goals](explanation/design-goals)
-```
-````
+- [API reference](reference/jubilant)
 
+This documentation uses the [Diátaxis documentation structure](https://diataxis.fr/).
 
 ## Releases
 
 [Jubilant releases](https://github.com/canonical/jubilant/releases) are tracked on GitHub, and use [semantic versioning](https://semver.org/). To get notified when there's a new release, watch the [Jubilant repository](https://github.com/canonical/jubilant).
-
 
 ## Project and community
 
@@ -64,10 +44,4 @@ Jubilant is a member of the Ubuntu family. It's an open source project ([Apache 
 
 For support, join [Charm Development](https://matrix.to/#/#charmhub-charmdev:ubuntu.com) on Matrix. You'll be able to chat with the maintainers of Jubilant (the Canonical Charm Tech team) and a friendly community of charm developers!
 
-## Looking for more?
-
-The Ops repository has several [demo charms](https://github.com/canonical/operator/tree/main/examples) that you can experiment with. The demo charms use Jubilant for their integration tests.
-
 To follow along with updates and tips about charm development, join our [Discourse forum](https://discourse.charmhub.io/).
-
-[Learn more about the Juju ecosystem](https://canonical.com/juju/docs)


### PR DESCRIPTION
This PR updates the homepage of the Jubilant docs to use a similar style to [Ops](https://documentation.ubuntu.com/jubilant/).

Although in fact the most significant change is that I've reworked the intro - especially the advice about charm integration testing, as we now want to recommend `pytest-jubilant` and direct people to the Ops docs. Given that, it would be best for https://github.com/canonical/operator/pull/2406 to merge before this PR.

**[Preview of updated homepage](https://canonical-ubuntu-documentation-library--287.com.readthedocs.build/jubilant/)**

I decided that since we have so few doc pages, it's overkill to have "In this documentation" with an itemised table plus "How this documentation is organised". I tried it, but it looked simultaneously too sparse and too noisy with repeated links. For now, I think a simple "In this documentation" list is better.

---

Merge this after https://github.com/canonical/operator/pull/2406