### PR TITLE
ci: run CI (especially integration tests) every Monday morning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
           - edge
   schedule:
     # min (0-59) / hour (0-23) / day (1-31) / month (1-12) / weekday (SUN-SAT)
-    - cron: "0 10 * * MON"
+    - cron: "43 6 * * MON"
       timezone: "Pacific/Auckland"
 
 permissions: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Run unit tests
         run: make unit
 
-  init:
+  init-integration:
     runs-on: ubuntu-latest
 
     outputs:
@@ -87,13 +87,13 @@ jobs:
           echo "juju-channels=[\"3/$RISK\", \"4/$RISK\"]" >> "$GITHUB_OUTPUT"
 
   integration-k8s:
-    needs: init
+    needs: init-integration
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ${{ fromJSON(needs.init.outputs.juju-channels) }}
+        juju-channel: ${{ fromJSON(needs.init-integration.outputs.juju-channels) }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.juju-channel }}-k8s
@@ -121,13 +121,13 @@ jobs:
         run: make integration-k8s
 
   integration-machine:
-    needs: init
+    needs: init-integration
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ${{ fromJSON(needs.init.outputs.juju-channels) }}
+        juju-channel: ${{ fromJSON(needs.init-integration.outputs.juju-channels) }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.juju-channel }}-machine

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         run: make lint
 
   unit:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ on:
           - stable
           - candidate
           - beta
-          - edge
   schedule:
     # min (0-59) / hour (0-23) / day (1-31) / month (1-12) / weekday (SUN-SAT)
     - cron: "43 6 * * MON"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         run: make lint
 
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,11 +69,6 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Work around https://github.com/canonical/concierge/issues/30
-        run: |
-          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
-          sudo rm -rf /run/containerd
-
       - name: Check out repo
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_call:
   workflow_dispatch:
+  schedule:
+    # min (0-59) / hour (0-23) / day (1-31) / month (1-12) / weekday (SUN-SAT)
+    - cron: "0 10 * * MON"
+      timezone: "Pacific/Auckland"
 
 permissions: {}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,3 +153,21 @@ jobs:
 
       - name: Run integration tests
         run: make integration-machine
+
+  open-issue-on-failure-if-scheduled:
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: [integration-k8s, integration-machine]
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Create issue on failure
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Scheduled tests failed" \
+            --body "Scheduled tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,11 +76,14 @@ jobs:
     steps:
       - name: Resolve Juju channels
         id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel }}
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "$EVENT_NAME" = "schedule" ]; then
             RISK="beta"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RISK="${{ github.event.inputs.channel }}"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RISK="$INPUT_CHANNEL"
           else
             RISK="stable"
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,17 @@ on:
   pull_request:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Juju channel risk (scheduled runs use beta, everything else uses stable)"
+        required: true
+        type: choice
+        default: stable
+        options:
+          - stable
+          - candidate
+          - beta
+          - edge
   schedule:
     # min (0-59) / hour (0-23) / day (1-31) / month (1-12) / weekday (SUN-SAT)
     - cron: "0 10 * * MON"
@@ -56,13 +67,33 @@ jobs:
       - name: Run unit tests
         run: make unit
 
+  init:
+    runs-on: ubuntu-latest
+
+    outputs:
+      juju-channels: ${{ steps.resolve.outputs.juju-channels }}
+
+    steps:
+      - name: Resolve Juju channels
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            RISK="beta"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RISK="${{ github.event.inputs.channel }}"
+          else
+            RISK="stable"
+          fi
+          echo "juju-channels=[\"3/$RISK\", \"4/$RISK\"]" >> "$GITHUB_OUTPUT"
+
   integration-k8s:
+    needs: init
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ["3/stable", "4/stable"]
+        juju-channel: ${{ fromJSON(needs.init.outputs.juju-channels) }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.juju-channel }}-k8s
@@ -90,12 +121,13 @@ jobs:
         run: make integration-k8s
 
   integration-machine:
+    needs: init
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        juju-channel: ["3/stable", "4/stable"]
+        juju-channel: ${{ fromJSON(needs.init.outputs.juju-channels) }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.juju-channel }}-machine


### PR DESCRIPTION
This PR updates CI to run on a schedule, every Monday morning. The goal is to ensure that we're running against new Juju releases in a relatively timely manner, so we don't run into breakages in the middle of other PRs (as we did in #264). The current [Juju release cadence](https://documentation.ubuntu.com/juju/latest/releasenotes/juju_4.0.x/) appears to be roughly monthly, but is very variable. Resolves #265.

This PR also removes the now-unnecessary workaround step for the resolved `concierge` issue https://github.com/canonical/concierge/issues/30