### PR TITLE
ci: fix unit runs-on

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,16 @@ jobs:
         run: make lint
 
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.10", "3.12", "3.14"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
 
     steps:
       - name: Check out repo


### PR DESCRIPTION
This PR fixes a bug in our CI, where `matrix.os` wasn't used for unit tests, we always ran on `ubuntu-latest`.