### PR TITLE
fix: add ./ for relative pathlib.Path objects in _deploy_tempdir

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -1690,6 +1690,9 @@ class Juju:
         resources: Mapping[str, str] | None,
     ) -> Generator[tuple[str | None, Mapping[str, str] | None]]:
         if isinstance(charm, pathlib.Path):
+            # We add "./" to any relative pathlib.Path objects in their string form.
+            # pathlib.Path removes the redundant "./", which we need to prevent Juju
+            # from saying the path is ambiguos.
             charm = str(charm) if charm.is_absolute() else f'./{charm}'
         charm_needs_temp = charm is not None and charm.startswith(('.', '/'))
         resources_needs_temp = resources is not None and any(

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -1692,7 +1692,7 @@ class Juju:
         if isinstance(charm, pathlib.Path):
             # We add "./" to any relative pathlib.Path objects in their string form.
             # pathlib.Path removes the redundant "./", which we need to prevent Juju
-            # from saying the path is ambiguos.
+            # from saying the path is ambiguous.
             charm = str(charm) if charm.is_absolute() else f'./{charm}'
         charm_needs_temp = charm is not None and charm.startswith(('.', '/'))
         resources_needs_temp = resources is not None and any(

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -1689,8 +1689,8 @@ class Juju:
         charm: str | pathlib.Path | None,
         resources: Mapping[str, str] | None,
     ) -> Generator[tuple[str | None, Mapping[str, str] | None]]:
-        if charm is not None:
-            charm = str(charm)
+        if isinstance(charm, pathlib.Path):
+            charm = str(charm) if charm.is_absolute() else f'./{charm}'
         charm_needs_temp = charm is not None and charm.startswith(('.', '/'))
         resources_needs_temp = resources is not None and any(
             v.startswith(('.', '/')) for v in resources.values()

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pathlib
 import urllib.request
 
 import pytest
@@ -69,18 +68,6 @@ def test_deploy_with_resources(juju: jubilant.Juju):
 def test_deploy_with_local_file_resource(juju: jubilant.Juju, empty_tar: str):
     juju.deploy(
         helpers.find_charm('testapp'),
-        resources={'test-file': empty_tar},
-    )
-    juju.wait(
-        lambda status: 'testapp' in status.apps and 'testapp/0' in status.apps['testapp'].units
-    )
-
-
-def test_deploy_with_local_file_resource_relative(juju: jubilant.Juju, empty_tar: str):
-    charm = helpers.find_charm('testapp')
-    relative_charm = charm.relative_to(pathlib.Path(__file__).cwd())
-    juju.deploy(
-        relative_charm,
         resources={'test-file': empty_tar},
     )
     juju.wait(

--- a/tests/integration/test_deployment.py
+++ b/tests/integration/test_deployment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 import urllib.request
 
 import pytest
@@ -68,6 +69,18 @@ def test_deploy_with_resources(juju: jubilant.Juju):
 def test_deploy_with_local_file_resource(juju: jubilant.Juju, empty_tar: str):
     juju.deploy(
         helpers.find_charm('testapp'),
+        resources={'test-file': empty_tar},
+    )
+    juju.wait(
+        lambda status: 'testapp' in status.apps and 'testapp/0' in status.apps['testapp'].units
+    )
+
+
+def test_deploy_with_local_file_resource_relative(juju: jubilant.Juju, empty_tar: str):
+    charm = helpers.find_charm('testapp')
+    relative_charm = charm.relative_to(pathlib.Path(__file__).cwd())
+    juju.deploy(
+        relative_charm,
         resources={'test-file': empty_tar},
     )
     juju.wait(

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -111,7 +111,7 @@ def test_overlays_str():
 
 
 def test_path(run: mocks.Run):
-    run.handle(['juju', 'deploy', 'xyz'])
+    run.handle(['juju', 'deploy', './xyz'])
     juju = jubilant.Juju()
 
     juju.deploy(pathlib.Path('xyz'))

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -117,6 +117,13 @@ def test_path(run: mocks.Run):
     juju.deploy(pathlib.Path('xyz'))
 
 
+def test_path_absolute(run: mocks.Run):
+    run.handle(['juju', 'deploy', '/xyz'])
+    juju = jubilant.Juju()
+
+    juju.deploy(pathlib.Path('/xyz'))
+
+
 def test_tempdir(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
     num_calls = 0
 

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -79,6 +79,13 @@ def test_path(run: mocks.Run):
     juju.refresh('xyz', path=pathlib.Path('foo'))
 
 
+def test_path_absolute(run: mocks.Run):
+    run.handle(['juju', 'refresh', 'xyz', '--path', '/foo'])
+    juju = jubilant.Juju()
+
+    juju.refresh('xyz', path=pathlib.Path('/foo'))
+
+
 def test_tempdir(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
     num_calls = 0
 

--- a/tests/unit/test_refresh.py
+++ b/tests/unit/test_refresh.py
@@ -73,7 +73,7 @@ def test_all_args(run: mocks.Run):
 
 
 def test_path(run: mocks.Run):
-    run.handle(['juju', 'refresh', 'xyz', '--path', 'foo'])
+    run.handle(['juju', 'refresh', 'xyz', '--path', './foo'])
     juju = jubilant.Juju()
 
     juju.refresh('xyz', path=pathlib.Path('foo'))


### PR DESCRIPTION
Fixes #277 .

This PR modifies how `_deploy_tempdir` handles the `charm` parameter when it is a `pathlib.Path` object.
- If `charm` is an absolute path, we coerce it to a string, preserving its original path.
- If `charm` is a relative path, we coerce it to a string, and append `./` to the beginning.

I used `is_absolute()` instead of `root` to decide if a `pathlib.Path` object is absolute or not.

I added unit tests for deploying and refreshing from relative `pathlib.Path` objects.

**As a code reviewer, you can skip the below sections**

<details>
<summary> About the reverted commit </summary>


I added an integration test in https://github.com/canonical/jubilant/pull/317/commits/de01a1a749cf34af92ca4dba76ee74aa2e34e99d, which I later reverted:
- The test re-deploy the same `testapp` charm into the model.
- It didn't test what I wanted: all relative charm paths are converted to absolute paths in our CI, which has Juju installed as a snap https://github.com/canonical/jubilant/blob/5fd298b704724d8afb2c18828cd60828bda91fc3/jubilant/_juju.py#L1703-L1710

</details>

<details>

<summary> Discussing the suggestions in #277 </summary>

The original ticket mentioned multiple approaches. I will go through them one by one to explain why I didn't pick them:

### 1.

```python
        if isinstance(charm, pathlib.Path):
            charm = str(charm.absolute())
        charm_needs_temp = charm is not None and charm.startswith(('.', '/'))
```
This works well. However, calling `charm.absolute()` would:
- Make unit testing difficult, as `charm.absolute()` behaves based on where the unit tests are run (e.g. on my local machine `/home/tromai/.../jubilant/xyz` in Github Actions `/runner/.../zyx`).
- Forcing absolute path will break deploying/refreshing from a relative `pathlib.Path`object  (although I am not sure if anyone depends on this behavior).

### 2.
```python
        charm_needs_temp = (
            isinstance(charm, pathlib.Path)
            or 
            ( <-- Assumed brackets, not in the original text
                isinstance(charm, str) and charm.startswith(('.', '/'))
            ) <-- Assumed brackets, not in the original text
        )
        if charm is not None:
            charm = str(charm)
```
I am not sure this fix resolves the original issue, as `str(charm)` still remove redundant "./" in relative `pathlib.Path` objects.

</details>