### PR TITLE
test: remove Juju 4.0.2/4.0.3 exec stdout newline workaround

### DIFF
--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -76,32 +76,22 @@ def test_run_unit_not_found(juju: jubilant.Juju):
         juju.run('testdb/42', 'do-thing')
 
 
-def test_exec_success(juju: jubilant.Juju, juju_version: jubilant.Version):
+def test_exec_success(juju: jubilant.Juju):
     task = juju.exec('echo foo', unit='testdb/0')
     assert task.success
     assert task.return_code == 0
-    # Juju 4.0.2 and 4.0.3 strip newlines from exec stdout.
-    expected_foo = 'foo\n'
-    expected_bar_baz = 'bar baz\n'
-    if juju_version.major == 4:
-        expected_foo = expected_foo.rstrip('\n')
-        expected_bar_baz = expected_bar_baz.rstrip('\n')
-    assert task.stdout == expected_foo
+    assert task.stdout == 'foo\n'
     assert task.stderr == ''
 
     task = juju.exec('echo', 'bar', 'baz', unit='testdb/0')
     assert task.success
-    assert task.stdout == expected_bar_baz
+    assert task.stdout == 'bar baz\n'
 
 
-def test_exec_leader(juju: jubilant.Juju, juju_version: jubilant.Version):
+def test_exec_leader(juju: jubilant.Juju):
     task = juju.exec('echo foo', unit='testdb/leader')
     assert task.success
-    # Juju 4.0.2 and 4.0.3 strip newlines from exec stdout.
-    expected = 'foo\n'
-    if juju_version.major == 4:
-        expected = expected.rstrip('\n')
-    assert task.stdout == expected
+    assert task.stdout == 'foo\n'
 
 
 def test_exec_error(juju: jubilant.Juju):

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -36,22 +36,16 @@ def setup(juju: jubilant.Juju, private_key_file: str):
     juju.wait(jubilant.all_active)
 
 
-def test_exec(juju: jubilant.Juju, juju_version: jubilant.Version):
+def test_exec(juju: jubilant.Juju):
     task = juju.exec('echo foo', machine=0)
     assert task.success
     assert task.return_code == 0
-    # Juju 4.0.2 and 4.0.3 strip newlines from exec stdout.
-    expected_foo = 'foo\n'
-    expected_bar_baz = 'bar baz\n'
-    if juju_version.major == 4:
-        expected_foo = expected_foo.rstrip('\n')
-        expected_bar_baz = expected_bar_baz.rstrip('\n')
-    assert task.stdout == expected_foo
+    assert task.stdout == 'foo\n'
     assert task.stderr == ''
 
     task = juju.exec('echo', 'bar', 'baz', machine=0)
     assert task.success
-    assert task.stdout == expected_bar_baz
+    assert task.stdout == 'bar baz\n'
 
 
 def test_ssh(juju: jubilant.Juju, private_key_file: str):


### PR DESCRIPTION
The trailing-newline-stripping bug (juju/juju#21927) has been fixed upstream, so the `if juju_version.major == 4` branch in the exec tests now causes failures against 4.1-beta1. Drop the workaround and assert the correct stdout directly.

We shouldn't merge this until the fixes are out of beta, since they fail (correctly) in stable. I don't think we want to have temporary logic that handles both stable and beta cases, just hold off on merging.

[Run in my fork](https://github.com/tonyandrewmeyer/jubilant/actions/runs/26117582129). Note that the timeout issues are separate.

Fixes #320.