### PR TITLE
ci: use sbomber to security scan and generate SBOM on release

### DIFF
--- a/.github/.sbomber-manifest.yaml
+++ b/.github/.sbomber-manifest.yaml
@@ -1,0 +1,25 @@
+clients:
+  sbom:
+    service_url: https://sbom-request.canonical.com
+    department: charm_engineering
+    email: tony.meyer@canonical.com
+    team: charm_tech
+  secscan: {}
+
+artifacts:
+  - name: 'jubilant'
+    type: 'sdist'
+    compression: 'gz'
+    source: 'dist/jubilant-__VERSION__.tar.gz'
+    ssdlc_params:
+      name: 'jubilant'
+      version: ''
+      channel: 'stable'
+
+  - name: 'jubilant'
+    type: 'wheel'
+    source: 'dist/jubilant-__VERSION__-py3-none-any.whl'
+    ssdlc_params:
+      name: 'jubilant'
+      version: ''
+      channel: 'stable'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -31,3 +33,6 @@ jobs:
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  secscan:
+    uses: ./.github/workflows/sbom-secscan.yaml

--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -1,0 +1,34 @@
+name: SBOM and secscan
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scan:
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Render manifest with built artifact version
+        run: |
+          version=$(ls dist/jubilant-*.tar.gz | sed -E 's|dist/jubilant-(.*)\.tar\.gz|\1|')
+          sed "s/__VERSION__/${version}/g" .github/.sbomber-manifest.yaml > "${RUNNER_TEMP}/sbomber-manifest.yaml"
+          cat "${RUNNER_TEMP}/sbomber-manifest.yaml"
+
+      - name: sbomber
+        uses: canonical/sbomber/.github/actions/run@cf7a76e810497ec932e8285b2c9d6b373d225e79  # main -- the sbomber-ref input below should match
+        with:
+          manifest: ${{ runner.temp }}/sbomber-manifest.yaml
+          artifact-name: secscan-report-upload
+          sbomber-ref: cf7a76e810497ec932e8285b2c9d6b373d225e79  # should match the ref in 'uses' above

--- a/README.md
+++ b/README.md
@@ -86,5 +86,6 @@ To create a new release of Jubilant:
 
 1. Update the `__version__` field in [`jubilant/__init__.py`](https://github.com/canonical/jubilant/blob/main/jubilant/__init__.py) to the new version you want to release.
 2. Push up a PR with this change and get it reviewed and merged.
-3. Create a [new release](https://github.com/canonical/jubilant/releases/new) on GitHub with good release notes. The tag should start with a `v`, like `v1.2.3`. Once you've created the release, the [`publish.yaml` workflow](https://github.com/canonical/jubilant/blob/main/.github/workflows/publish.yaml) will automatically publish it to PyPI.
-4. Once the publish workflow has finished, check that the new version appears in the [PyPI version history](https://pypi.org/project/jubilant/#history).
+3. Create a [new release](https://github.com/canonical/jubilant/releases/new) on GitHub with good release notes. The tag should start with a `v`, like `v1.2.3`. Once you've created the release, the [`publish.yaml` workflow](https://github.com/canonical/jubilant/blob/main/.github/workflows/publish.yaml) will automatically publish it to PyPI and run the SBOM and security scan workflow.
+4. On the summary page of the Publish workflow run, locate the `secscan-report-upload` artifact. Download it and upload it to the [SSDLC Jubilant folder in Drive](https://drive.google.com/drive/folders/1bLJL4wJwicxaGY2hc5Xz4vSjENUt5Zjw?usp=share_link). Open the report and verify that the security scan has not found any vulnerabilities.
+5. Once the publish workflow has finished, check that the new version appears in the [PyPI version history](https://pypi.org/project/jubilant/#history).


### PR DESCRIPTION
Automates the security scanning and SBOM generation on release, like with pebble and operator.

Uses sbomber to run the secscan tool. Unlike Pebble, we know the version locally, so can run the tool with locally built versions rather than needing to download from PyPI, avoiding race conditions.