### PR TITLE
docs: move dataclass codegen note from docs to comment; consolidate

### DIFF
--- a/jubilant/modeltypes.py
+++ b/jubilant/modeltypes.py
@@ -1,10 +1,8 @@
-"""Dataclasses that contain parsed output from ``juju show-model --format=json``.
+"""Dataclasses that contain parsed output from ``juju show-model --format=json``."""
 
-These dataclasses were originally `generated from <https://github.com/juju/juju/compare/main...benhoyt:juju:modelinfo-dataclasses-4>`_
-the Go structs in the Juju codebase, to ensure they are correct. Class names
-come from the Go struct name, whereas attribute names come from the JSON field
-names.
-"""
+# These dataclasses were originally generated from the Go structs in the Juju codebase.
+# See the comment at the top of statustypes.py for details (but use the
+# "modelinfo-dataclasses-4" branch).
 
 from __future__ import annotations
 

--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -1,11 +1,17 @@
-"""Dataclasses that contain parsed output from ``juju status --format=json``.
+"""Dataclasses that contain parsed output from ``juju status --format=json``."""
 
-These dataclasses were originally `generated from <https://github.com/juju/juju/compare/main...benhoyt:juju:status-dataclasses>`_
-the Go structs in the Juju codebase, to ensure they are correct. Class names
-come from the Go struct name, whereas attribute names come from the JSON field
-names. The one exception is that "Application" has been renamed to "App"
-throughout, for brevity (and "application" to "app").
-"""
+# These dataclasses were originally generated from the Go structs in the Juju codebase,
+# to ensure they are correct. Class names come from the Go struct name, whereas
+# attribute names come from the JSON field names. The one exception is that
+# "application" has been renamed to "app" throughout, for brevity.
+#
+# Our intention is that they are generated once, but updated manually. We've already
+# made a few manual updates, for example, simplifying comprehensions (#234).
+#
+# To regenerate from scratch, check out the "status-dataclasses-4.0" branch of the
+# https://github.com/benhoyt/juju fork, and run:
+#
+#     go run ./cmd/getfields
 
 from __future__ import annotations
 

--- a/jubilant/statustypes.py
+++ b/jubilant/statustypes.py
@@ -1,12 +1,13 @@
 """Dataclasses that contain parsed output from ``juju status --format=json``."""
 
 # These dataclasses were originally generated from the Go structs in the Juju codebase,
-# to ensure they are correct. Class names come from the Go struct name, whereas
+# to ensure they are correct. Class names come from the Go struct names, whereas
 # attribute names come from the JSON field names. The one exception is that
 # "application" has been renamed to "app" throughout, for brevity.
 #
-# Our intention is that they are generated once, but updated manually. We've already
-# made a few manual updates, for example, simplifying comprehensions (#234).
+# Our intention is that they are generated once when a new module is added, but updated
+# manually. We've already made a few manual updates, for example, simplifying
+# comprehensions (PR #234).
 #
 # To regenerate from scratch, check out the "status-dataclasses-4.0" branch of the
 # https://github.com/benhoyt/juju fork, and run:

--- a/jubilant/unittypes.py
+++ b/jubilant/unittypes.py
@@ -1,11 +1,8 @@
-"""Dataclasses that contain parsed output from ``juju show-unit --format=json``.
+"""Dataclasses that contain parsed output from ``juju show-unit --format=json``."""
 
-These dataclasses were originally `generated from <https://github.com/juju/juju/compare/main...benhoyt:juju:unittypes-dataclasses>`_
-the Go structs in the Juju codebase, to ensure they are correct. Class names
-come from the Go struct name, whereas attribute names come from the JSON field
-names. The one exception is that "Application" has been renamed to "App"
-throughout, for brevity (and "application" to "app").
-"""
+# These dataclasses were originally generated from the Go structs in the Juju codebase.
+# See the comment at the top of statustypes.py for details (but use the
+# "unittypes-dataclasses" branch).
 
 from __future__ import annotations
 


### PR DESCRIPTION
The copy-n-pasted documentation about the Go code generator in the `*types.py` files was getting a bit unwieldy. Plus, it should have been a comment, not in our documentation, as it's how the sausage is made and not important for users. 

Move it to a comment, consolidate in statustypes.py (and refer to there from other files), and add a few more details about how to run it.