### PR TITLE
ci: split Juju 4 channel into 4.0 and 4.1, add edge to scheduled runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "Juju channel risk (scheduled runs use beta, everything else uses stable)"
+        description: "Juju channel risk (PRs use stable; scheduled runs use stable and edge)"
         required: true
         type: choice
         default: stable
@@ -17,6 +17,7 @@ on:
           - stable
           - candidate
           - beta
+          - edge
   schedule:
     # min (0-59) / hour (0-23) / day (1-31) / month (1-12) / weekday (SUN-SAT)
     - cron: "43 6 * * MON"
@@ -82,14 +83,19 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_CHANNEL: ${{ github.event.inputs.channel }}
         run: |
+          # 4.1/stable does not exist yet, so it is only included for non-stable risks.
           if [ "$EVENT_NAME" = "schedule" ]; then
-            RISK="beta"
+            CHANNELS='["3/stable", "3/edge", "4.0/stable", "4.0/edge", "4.1/edge"]'
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            RISK="$INPUT_CHANNEL"
+            if [ "$INPUT_CHANNEL" = "stable" ]; then
+              CHANNELS='["3/stable", "4.0/stable"]'
+            else
+              CHANNELS="[\"3/$INPUT_CHANNEL\", \"4.0/$INPUT_CHANNEL\", \"4.1/$INPUT_CHANNEL\"]"
+            fi
           else
-            RISK="stable"
+            CHANNELS='["3/stable", "4.0/stable"]'
           fi
-          echo "juju-channels=[\"3/$RISK\", \"4/$RISK\"]" >> "$GITHUB_OUTPUT"
+          echo "juju-channels=$CHANNELS" >> "$GITHUB_OUTPUT"
 
   integration-k8s:
     needs: init-integration
@@ -117,7 +123,9 @@ jobs:
         run: sudo snap install --classic concierge
 
       - name: Prepare Juju
-        run: sudo concierge prepare --verbose --juju-channel=${{ matrix.juju-channel }} --charmcraft-channel=3.x/stable -p k8s
+        env:
+          JUJU_CHANNEL: ${{ matrix.juju-channel }}
+        run: sudo concierge prepare --verbose --juju-channel="$JUJU_CHANNEL" --charmcraft-channel=3.x/stable -p k8s
 
       - name: Pack test charms
         run: make pack
@@ -151,7 +159,9 @@ jobs:
         run: sudo snap install --classic concierge
 
       - name: Prepare Juju
-        run: sudo concierge prepare --verbose --juju-channel=${{ matrix.juju-channel }} --charmcraft-channel=3.x/stable -p machine
+        env:
+          JUJU_CHANNEL: ${{ matrix.juju-channel }}
+        run: sudo concierge prepare --verbose --juju-channel="$JUJU_CHANNEL" --charmcraft-channel=3.x/stable -p machine
 
       - name: Pack test charms
         run: make pack


### PR DESCRIPTION
[Juju's edge builds are now usable](https://discourse.canonical.com/t/charming-engineering-lt-notes-4th-june-2026/7578?u=tony-meyer). This PR switches from candidate to edge to get faster information about when Juju breaks Jubilant. Also adds edge as a manual dispatch option.

It was also a bit confusing recently as to whether 4.0/candidate or only 4.1/candidate had a fix, and we had to compare stable on a PR run. Adjust the scheduled run to do all of these for easy comparison, except 4.1/stable as that doesn't have a release yet.

Drive-by fix to move matrix.juju-channel through an env var on both Prepare Juju steps to clear the pre-existing zizmor template-injection warning.