### PR TITLE
docs: clarify behaviour when providing a user in the model value

### DIFF
--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -63,7 +63,7 @@ class Juju:
     Args:
         model: If specified, operate on this Juju model, otherwise use the current Juju model.
             The model name is passed through to the Juju CLI unchanged, so the full
-            ``[<controller>:][<user>/]<model>`` form is accepted: Prefix the name with with
+            ``[<controller>:][<user>/]<model>`` form is accepted: Prefix the name with
             ``<user>/`` to operate on another user's model on the current controller. Prefix the
             name with ``<controller>:`` to operate on a model in another controller. For example,
             ``alice/my-model`` or ``mycontroller:alice/my-model``.
@@ -77,12 +77,12 @@ class Juju:
     """If not None, operate on this Juju model, otherwise use the current Juju model.
 
     The model name is passed through to the Juju CLI unchanged, so the full
-    ``[<controller>:][<user>/]<model>`` form is accepted. Prefix the name with ``<controller>:``
-    to operate on a model in another controller; prefix it with ``<user>/`` to operate on another
-    user's model on the current controller. For example::
+    ``[<controller>:][<user>/]<model>`` form is accepted. Prefix the name with ``<user>/`` to
+    operate on another user's model on the current controller; prefix it with ``<controller>:``
+    to operate on a model in another controller. For example::
 
-        juju = jubilant.Juju(model='mycontroller:my-model')
         juju = jubilant.Juju(model='alice/my-model')
+        juju = jubilant.Juju(model='mycontroller:my-model')
         juju = jubilant.Juju(model='mycontroller:alice/my-model')
     """
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -63,10 +63,10 @@ class Juju:
     Args:
         model: If specified, operate on this Juju model, otherwise use the current Juju model.
             The model name is passed through to the Juju CLI unchanged, so the full
-            ``[<controller>:][<user>/]<model>`` form is accepted: prefix the name with
-            ``<controller>:`` to operate on a model in another controller, and prefix it
-            with ``<user>/`` to operate on another user's model on the current controller
-            (for example ``alice/my-model`` or ``mycontroller:alice/my-model``).
+            ``[<controller>:][<user>/]<model>`` form is accepted: Prefix the name with with
+            ``<user>/`` to operate on another user's model on the current controller. Prefix the
+            name with ``<controller>:`` to operate on a model in another controller. For example,
+            ``alice/my-model`` or ``mycontroller:alice/my-model``.
         wait_timeout: The default timeout for :meth:`wait` (in seconds) if that method's *timeout*
             parameter is not specified.
         cli_binary: Path to the Juju CLI binary. If not specified, uses ``juju`` and assumes it is

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -334,7 +334,12 @@ class Juju:
         model, all subsequent operations on this instance will use the new model.
 
         Args:
-            model: Name of model to add.
+            model: Name of model to add. Unlike :attr:`model` and most other
+                methods, this is **not** the ``[<controller>:][<user>/]<model>``
+                form: Juju's ``add-model`` only accepts a bare model name
+                (lowercase letters, digits, and hyphens). To add a model on a
+                different controller, pass *controller*; you cannot add a model
+                owned by another user.
             cloud: Name of cloud or region (or cloud/region) to use for the model.
             controller: Name of controller to operate in. If not specified, use the current
                 controller.

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -62,7 +62,11 @@ class Juju:
 
     Args:
         model: If specified, operate on this Juju model, otherwise use the current Juju model.
-            If the model is in another controller, prefix the model name with ``<controller>:``.
+            The model name is passed through to the Juju CLI unchanged, so the full
+            ``[<controller>:][<user>/]<model>`` form is accepted: prefix the name with
+            ``<controller>:`` to operate on a model in another controller, and prefix it
+            with ``<user>/`` to operate on another user's model on the current controller
+            (for example ``alice/my-model`` or ``mycontroller:alice/my-model``).
         wait_timeout: The default timeout for :meth:`wait` (in seconds) if that method's *timeout*
             parameter is not specified.
         cli_binary: Path to the Juju CLI binary. If not specified, uses ``juju`` and assumes it is
@@ -72,8 +76,14 @@ class Juju:
     model: str | None
     """If not None, operate on this Juju model, otherwise use the current Juju model.
 
-    If the model is in another controller, prefix the model name with ``<controller>:``; for
-    example, ``juju = jubilant.Juju(model='mycontroller:my-model')``.
+    The model name is passed through to the Juju CLI unchanged, so the full
+    ``[<controller>:][<user>/]<model>`` form is accepted. Prefix the name with ``<controller>:``
+    to operate on a model in another controller; prefix it with ``<user>/`` to operate on another
+    user's model on the current controller. For example::
+
+        juju = jubilant.Juju(model='mycontroller:my-model')
+        juju = jubilant.Juju(model='alice/my-model')
+        juju = jubilant.Juju(model='mycontroller:alice/my-model')
     """
 
     wait_timeout: float
@@ -778,7 +788,9 @@ class Juju:
         :attr:`model` to None.
 
         Args:
-            model: Name of model to destroy.
+            model: Name of model to destroy. Accepts the full
+                ``[<controller>:][<user>/]<model>`` form, for example ``alice/my-model`` or
+                ``mycontroller:alice/my-model``.
             destroy_storage: If true, destroy all storage instances in the model.
             force: If true, force model destruction and ignore any errors.
             no_wait: If true, rush through model destruction without waiting for each step
@@ -800,7 +812,7 @@ class Juju:
         if timeout is not None:
             args.extend(['--timeout', f'{timeout}s'])
         self.cli(*args, include_model=False)
-        if model == self.model:
+        if _same_model(model, self.model):
             self.model = None
 
     @overload
@@ -1379,7 +1391,8 @@ class Juju:
         """Get information about the current model (or another model).
 
         Args:
-            model: Name of the model or ``controller:model``. If omitted,
+            model: Name of the model. Accepts the full ``[<controller>:][<user>/]<model>`` form,
+                for example ``alice/my-model`` or ``mycontroller:alice/my-model``. If omitted,
                 return details about the current model.
         """
         args = ['show-model', '--format', 'json']
@@ -1800,6 +1813,37 @@ def _format_config(k: str, v: ConfigValue) -> str:
     if isinstance(v, bool):
         v = 'true' if v else 'false'
     return f'{k}={v}'
+
+
+def _parse_model_ref(s: str) -> tuple[str | None, str | None, str]:
+    controller: str | None = None
+    user: str | None = None
+    if ':' in s:
+        controller, s = s.split(':', 1)
+    if '/' in s:
+        user, s = s.split('/', 1)
+    return controller, user, s
+
+
+def _same_model(a: str | None, b: str | None) -> bool:
+    """Whether two ``[<controller>:][<user>/]<model>`` references identify the same model.
+
+    An unset controller or user on either side is treated as "the default" and
+    matches a set value on the other side; a set value on both sides must match.
+    """
+    if a is None or b is None:
+        return a is b
+    if a == b:
+        return True
+    ca, ua, ma = _parse_model_ref(a)
+    cb, ub, mb = _parse_model_ref(b)
+    if ma != mb:
+        return False
+    if ca and cb and ca != cb:
+        return False
+    if ua and ub and ua != ub:
+        return False
+    return True
 
 
 def _status_diff(old: Status | None, new: Status) -> str:

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -17,3 +17,22 @@ def test_show_model(juju: jubilant.Juju):
 
     info_model = juju.show_model(juju.model)
     assert info_model.model_uuid == info.model_uuid
+
+
+def test_user_qualified_model_name_is_transparent(juju: jubilant.Juju):
+    """Jubilant forwards ``[<controller>:][<user>/]<model>`` to the Juju CLI verbatim."""
+    assert juju.model is not None
+    info = juju.show_model()
+    user, _, _ = info.name.rpartition('/')
+    assert user, f'expected qualified model name, got {info.name!r}'
+    controller = info.controller_name
+
+    info_user = juju.show_model(f'{user}/{juju.model}')
+    assert info_user.model_uuid == info.model_uuid
+    info_full = juju.show_model(f'{controller}:{user}/{juju.model}')
+    assert info_full.model_uuid == info.model_uuid
+
+    juju_qual = jubilant.Juju(model=f'{user}/{juju.model}')
+    assert juju_qual.show_model().model_uuid == info.model_uuid
+    juju_full = jubilant.Juju(model=f'{controller}:{user}/{juju.model}')
+    assert juju_full.show_model().model_uuid == info.model_uuid

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -63,6 +63,24 @@ def test_include_model_with_model(run: mocks.Run):
     assert stdout == 'OUT'
 
 
+def test_include_model_with_user_qualified_model(run: mocks.Run):
+    run.handle(['juju', 'test', '--model', 'alice/mdl'], stdout='OUT')
+    juju = jubilant.Juju(model='alice/mdl')
+
+    stdout = juju.cli('test')
+
+    assert stdout == 'OUT'
+
+
+def test_include_model_with_controller_user_qualified_model(run: mocks.Run):
+    run.handle(['juju', 'test', '--model', 'ctrl:alice/mdl'], stdout='OUT')
+    juju = jubilant.Juju(model='ctrl:alice/mdl')
+
+    stdout = juju.cli('test')
+
+    assert stdout == 'OUT'
+
+
 def test_exclude_model_no_model(run: mocks.Run):
     run.handle(['juju', 'test'], stdout='OUT')
     juju = jubilant.Juju()

--- a/tests/unit/test_destroy_model.py
+++ b/tests/unit/test_destroy_model.py
@@ -22,6 +22,7 @@ def test_destroy_other(run: mocks.Run):
 
 
 def test_destroy_user_qualified(run: mocks.Run):
+    """destroy_model('alice/other') resets self.model when self.model == 'alice/other'."""
     run.handle(['juju', 'destroy-model', 'alice/other', '--no-prompt'])
     juju = jubilant.Juju(model='alice/other')
 
@@ -44,6 +45,36 @@ def test_destroy_unqualified_matches_qualified_self(run: mocks.Run):
     """destroy_model('m') resets self.model when self.model == 'admin/m'."""
     run.handle(['juju', 'destroy-model', 'm', '--no-prompt'])
     juju = jubilant.Juju(model='admin/m')
+
+    juju.destroy_model('m')
+
+    assert juju.model is None
+
+
+def test_destroy_controller_qualified(run: mocks.Run):
+    """destroy_model('c1:m') resets self.model when self.model == 'c1:m'."""
+    run.handle(['juju', 'destroy-model', 'c1:m', '--no-prompt'])
+    juju = jubilant.Juju(model='c1:m')
+
+    juju.destroy_model('c1:m')
+
+    assert juju.model is None
+
+
+def test_destroy_controller_qualified_matches_unqualified_self(run: mocks.Run):
+    """destroy_model('c1:m') resets self.model when self.model == 'm'."""
+    run.handle(['juju', 'destroy-model', 'c1:m', '--no-prompt'])
+    juju = jubilant.Juju(model='m')
+
+    juju.destroy_model('c1:m')
+
+    assert juju.model is None
+
+
+def test_destroy_controller_unqualified_matches_qualified_self(run: mocks.Run):
+    """destroy_model('m') resets self.model when self.model == 'c1:m'."""
+    run.handle(['juju', 'destroy-model', 'm', '--no-prompt'])
+    juju = jubilant.Juju(model='c1:m')
 
     juju.destroy_model('m')
 

--- a/tests/unit/test_destroy_model.py
+++ b/tests/unit/test_destroy_model.py
@@ -21,6 +21,55 @@ def test_destroy_other(run: mocks.Run):
     assert juju.model == 'initial'
 
 
+def test_destroy_user_qualified(run: mocks.Run):
+    run.handle(['juju', 'destroy-model', 'alice/other', '--no-prompt'])
+    juju = jubilant.Juju(model='alice/other')
+
+    juju.destroy_model('alice/other')
+
+    assert juju.model is None
+
+
+def test_destroy_qualified_matches_unqualified_self(run: mocks.Run):
+    """destroy_model('admin/m') resets self.model when self.model == 'm'."""
+    run.handle(['juju', 'destroy-model', 'admin/m', '--no-prompt'])
+    juju = jubilant.Juju(model='m')
+
+    juju.destroy_model('admin/m')
+
+    assert juju.model is None
+
+
+def test_destroy_unqualified_matches_qualified_self(run: mocks.Run):
+    """destroy_model('m') resets self.model when self.model == 'admin/m'."""
+    run.handle(['juju', 'destroy-model', 'm', '--no-prompt'])
+    juju = jubilant.Juju(model='admin/m')
+
+    juju.destroy_model('m')
+
+    assert juju.model is None
+
+
+def test_destroy_different_user_does_not_reset_self(run: mocks.Run):
+    """destroy_model('bob/m') is a different model from self.model == 'alice/m'."""
+    run.handle(['juju', 'destroy-model', 'bob/m', '--no-prompt'])
+    juju = jubilant.Juju(model='alice/m')
+
+    juju.destroy_model('bob/m')
+
+    assert juju.model == 'alice/m'
+
+
+def test_destroy_different_controller_does_not_reset_self(run: mocks.Run):
+    """destroy_model('c2:m') is a different model from self.model == 'c1:m'."""
+    run.handle(['juju', 'destroy-model', 'c2:m', '--no-prompt'])
+    juju = jubilant.Juju(model='c1:m')
+
+    juju.destroy_model('c2:m')
+
+    assert juju.model == 'c1:m'
+
+
 def test_destroy_with_destroy_storage(run: mocks.Run):
     run.handle(['juju', 'destroy-model', 'xyz', '--no-prompt', '--destroy-storage'])
     juju = jubilant.Juju()


### PR DESCRIPTION
I validated each Jubilant method in the four forms (plain model, model and controller, model and user, controller and user). They 'just work' except in the case of add-model (and a destroy-model Jubilant issue, as below).

The PR explains this in the `model` attribute docstring and the `__init__` arg, and (for the not working case) `add_model` arg. If we want to support adding a model owned by someone else, I believe would need to add an `owner` arg that translates into `--owner`. I'm leaving that until someone asks for it.

A small issue in `destroy_model` is also fixed, where we would not properly check whether it was the same model if the user was provided (a qualified user vs. unqualified).

Fixes #281