### PR TITLE
test: adopt -Werror in unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,9 @@ reportPrivateUsage = false  # silence errors about use of _from_dict outside cla
 reportUnnecessaryTypeIgnoreComment = "error"
 
 [tool.pytest.ini_options]
+filterwarnings = [
+  "error",
+]
 markers = [
   "machine: integration tests that require a Juju machine model",
 ]


### PR DESCRIPTION
This PR adds `filterwarnings = ["error"]` to `[tool.pytest.ini_options]` so the unit suite treats all warnings as errors, matching the -Werror adoption landed in canonical/operator#2541.

The jubilant unit suite was already clean under `-W error` 🎉.