### PR TITLE
docs: clarify behaviour of any_* methods and fix various small issues

### DIFF
--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -148,7 +148,7 @@ juju.wait(lambda _: requests.get('http://workload/status').ok)
 
 ## Fall back to `Juju.cli` if needed
 
-Many common Juju commands are already defined on the `Juju` class, such as [`deploy`](jubilant.Juju.deploy) and [`integrate`](jubilant.Juju.deploy).
+Many common Juju commands are already defined on the `Juju` class, such as [`deploy`](jubilant.Juju.deploy) and [`integrate`](jubilant.Juju.integrate).
 
 However, if you want to run a Juju command that's not yet defined in Jubilant, you can fall back to calling the [`Juju.cli`](jubilant.Juju.cli) method. For example, to fetch a model configuration value using `juju model-config`:
 

--- a/jubilant/_all_any.py
+++ b/jubilant/_all_any.py
@@ -83,7 +83,8 @@ def any_active(status: Status, *apps: str) -> bool:
 
     Args:
         status: The status object being tested.
-        apps: If provided, only these applications (and their units) are tested.
+        apps: If provided, only these applications (and their units) are tested. If an app is not
+            present in ``status.apps``, the app is ignored.
     """
     return _any_status_is('active', status, apps)
 
@@ -95,7 +96,8 @@ def any_blocked(status: Status, *apps: str) -> bool:
 
     Args:
         status: The status object being tested.
-        apps: If provided, only these applications (and their units) are tested.
+        apps: If provided, only these applications (and their units) are tested. If an app is not
+            present in ``status.apps``, the app is ignored.
     """
     return _any_status_is('blocked', status, apps)
 
@@ -116,7 +118,8 @@ def any_error(status: Status, *apps: str) -> bool:
 
     Args:
         status: The status object being tested.
-        apps: If provided, only these applications (and their units) are tested.
+        apps: If provided, only these applications (and their units) are tested. If an app is not
+            present in ``status.apps``, the app is ignored.
     """
     return _any_status_is('error', status, apps)
 
@@ -128,7 +131,8 @@ def any_maintenance(status: Status, *apps: str) -> bool:
 
     Args:
         status: The status object being tested.
-        apps: If provided, only these applications (and their units) are tested.
+        apps: If provided, only these applications (and their units) are tested. If an app is not
+            present in ``status.apps``, the app is ignored.
     """
     return _any_status_is('maintenance', status, apps)
 
@@ -140,7 +144,8 @@ def any_waiting(status: Status, *apps: str) -> bool:
 
     Args:
         status: The status object being tested.
-        apps: If provided, only these applications (and their units) are tested.
+        apps: If provided, only these applications (and their units) are tested. If an app is not
+            present in ``status.apps``, the app is ignored.
     """
     return _any_status_is('waiting', status, apps)
 

--- a/jubilant/_all_any.py
+++ b/jubilant/_all_any.py
@@ -111,7 +111,7 @@ def any_error(status: Status, *apps: str) -> bool:
         # Use a lambda to wait for any of the apps specified (blog, mysql) to go into error.
         juju.wait(
             jubilant.all_active,
-            error=lambda status: jubilant.any_error(status, 'blog', 'mysql')),
+            error=lambda status: jubilant.any_error(status, 'blog', 'mysql'),
         )
 
     Args:

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -451,7 +451,7 @@ class Juju:
             juju = jubilant.Juju()
             juju.bootstrap('lxd', 'myctrl')
             juju.add_model('mymodel', controller='myctrl')
-            # self.model will be 'myctrl.mymodel' here
+            # self.model will be 'myctrl:mymodel' here
 
         Args:
             cloud: Name of cloud to bootstrap on. Initialization consists of creating a

--- a/jubilant/_pretty.py
+++ b/jubilant/_pretty.py
@@ -121,7 +121,7 @@ def gron(value: object, prefix: str = '') -> Generator[str]:
 
 
 def diff(seq1: Sequence[str], seq2: Sequence[str]) -> Generator[str]:
-    """Compare seq1 and seq1; yield lines that have been removed, changed, or added.
+    """Compare seq1 and seq2; yield lines that have been removed, changed, or added.
 
     Example::
 


### PR DESCRIPTION
This PR clarifies how the `any_*` methods handle apps that can't be found. I think it's worth mentioning because it's not 100% obvious; maybe the methods raise an error (for example).

I've also included some fixes for small issues found by Copilot.