### PR TITLE
chore: prepare for v1.11.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,28 @@
+# 1.11.0 - 29 Jun 2026
+
+## Features
+
+* add `show_unit` method in (#308)
+
+## Documentation
+
+* move dataclass codegen note from docs to comment; consolidate in (#336)
+* expand the security page to include more sections in (#332)
+* clarify behaviour when providing a user in the model value in (#340)
+* clarify behaviour of `any_*` methods and fix various small issues in (#344)
+* move docs to canonical.com/juju/docs/jubilant in (#337)
+
+## Refactoring
+
+* avoid `yaml.load()` call in `safe_load` to silence scanner false positive in (#331)
+
+## CI
+
+* split Juju 4 channel into 4.0 and 4.1, add edge to scheduled runs in (#338)
+* enforce Conventional Commits on PR titles in (#341)
+* attest build provenance for released artifacts in (#352)
+* add dependency-review-action on PRs in (#353)
+
 # 1.10.0 - 28 May 2026
 
 ## Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,26 +2,26 @@
 
 ## Features
 
-* add `show_unit` method in (#308)
+* add `show_unit` method (#308)
 
 ## Documentation
 
-* move dataclass codegen note from docs to comment; consolidate in (#336)
-* expand the security page to include more sections in (#332)
-* clarify behaviour when providing a user in the model value in (#340)
-* clarify behaviour of `any_*` methods and fix various small issues in (#344)
-* move docs to canonical.com/juju/docs/jubilant in (#337)
+* move dataclass codegen note from docs to comment; consolidate (#336)
+* expand the security page to include more sections (#332)
+* clarify behaviour when providing a user in the model value (#340)
+* clarify behaviour of `any_*` methods and fix various small issues (#344)
+* move docs to canonical.com/juju/docs/jubilant (#337)
 
 ## Refactoring
 
-* avoid `yaml.load()` call in `safe_load` to silence scanner false positive in (#331)
+* avoid `yaml.load()` call in `safe_load` to silence scanner false positive (#331)
 
 ## CI
 
-* split Juju 4 channel into 4.0 and 4.1, add edge to scheduled runs in (#338)
-* enforce Conventional Commits on PR titles in (#341)
-* attest build provenance for released artifacts in (#352)
-* add dependency-review-action on PRs in (#353)
+* split Juju 4 channel into 4.0 and 4.1, add edge to scheduled runs (#338)
+* enforce Conventional Commits on PR titles (#341)
+* attest build provenance for released artifacts (#352)
+* add dependency-review-action on PRs (#353)
 
 # 1.10.0 - 28 May 2026
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,26 +2,26 @@
 
 ## Features
 
-* add `show_unit` method (#308)
+* Add `show_unit` method (#308)
 
 ## Documentation
 
-* move dataclass codegen note from docs to comment; consolidate (#336)
-* expand the security page to include more sections (#332)
-* clarify behaviour when providing a user in the model value (#340)
-* clarify behaviour of `any_*` methods and fix various small issues (#344)
-* move docs to canonical.com/juju/docs/jubilant (#337)
+* Move dataclass codegen note from docs to comment; consolidate (#336)
+* Expand the security page to include more sections (#332)
+* Clarify behaviour when providing a user in the model value (#340)
+* Clarify behaviour of `any_*` methods and fix various small issues (#344)
+* Move docs to canonical.com/juju/docs/jubilant (#337)
 
 ## Refactoring
 
-* avoid `yaml.load()` call in `safe_load` to silence scanner false positive (#331)
+* Avoid `yaml.load()` call in `safe_load` to silence scanner false positive (#331)
 
 ## CI
 
-* split Juju 4 channel into 4.0 and 4.1, add edge to scheduled runs (#338)
-* enforce Conventional Commits on PR titles (#341)
-* attest build provenance for released artifacts (#352)
-* add dependency-review-action on PRs (#353)
+* Split Juju 4 channel into 4.0 and 4.1, add edge to scheduled runs (#338)
+* Enforce Conventional Commits on PR titles (#341)
+* Attest build provenance for released artifacts (#352)
+* Add dependency-review-action on PRs (#353)
 
 # 1.10.0 - 28 May 2026
 

--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -55,4 +55,4 @@ __all__ = [
     'unittypes',
 ]
 
-__version__ = '1.10.0'
+__version__ = '1.11.0'


### PR DESCRIPTION
Title:

```
v1.11.0:  juju show-unit
```

Release note:

```
## What's Changed
* feat: add show_unit method by @Guillaumebeuzeboc in https://github.com/canonical/jubilant/pull/308
* docs: move dataclass codegen note from docs to comment; consolidate in https://github.com/canonical/jubilant/pull/336
* docs: expand the security page to include more sections in https://github.com/canonical/jubilant/pull/332
* docs: clarify behaviour when providing a user in the model value in https://github.com/canonical/jubilant/pull/340
* docs: clarify behaviour of any_* methods and fix various small issues by in https://github.com/canonical/jubilant/pull/344
* docs: move docs to canonical.com/juju/docs/jubilant in https://github.com/canonical/jubilant/pull/337
* chore: enable ruff format preview to allow cuddled braces by in https://github.com/canonical/jubilant/pull/343
* chore: rename .github/zizmor.yml to .github/zizmor.yaml in https://github.com/canonical/jubilant/pull/350
* test: remove Juju 4.0.2/4.0.3 exec stdout newline workaround in https://github.com/canonical/jubilant/pull/321
* test: mock shutil.which in unit tests; avoid assuming juju not installed as snap in https://github.com/canonical/jubilant/pull/330
* test: adopt -Werror in unit tests in https://github.com/canonical/jubilant/pull/342
* refactor: avoid yaml.load() call in safe_load to silence scanner false positive in https://github.com/canonical/jubilant/pull/331
* ci: split Juju 4 channel into 4.0 and 4.1, add edge to scheduled runs in https://github.com/canonical/jubilant/pull/338
* ci: enforce Conventional Commits on PR titles by in https://github.com/canonical/jubilant/pull/341
* ci: attest build provenance for released artifacts in https://github.com/canonical/jubilant/pull/352
* ci: add dependency-review-action on PRs in https://github.com/canonical/jubilant/pull/353

## New Contributors
* @Guillaumebeuzeboc made their first contribution in https://github.com/canonical/jubilant/pull/308

**Full Changelog**: https://github.com/canonical/jubilant/compare/v1.10.0...v1.11.0
```
