### PR TITLE
chore: set dependabot commit-message prefix to "chore" (no scope)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,7 +19,6 @@ updates:
       prefix: "chore"
     cooldown:
       default-days: 7
-      semver-major-days: 14
     groups:
       actions:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,6 +15,8 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 100
+    commit-message:
+      prefix: "chore"
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -33,6 +35,8 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 100
+    commit-message:
+      prefix: "chore"
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
Follow-up to the dependabot conventions rollout ([jubilant#365](https://github.com/canonical/jubilant/pull/365)). Add explicit `commit-message.prefix: "chore"` on every `updates:` entry so Dependabot always produces the plain `chore: bump foo to 1.2.3` shape.