### PR TITLE
chore: rolling uv exclude-newer supply-chain quarantine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ version = {attr = "jubilant.__version__"}
 [tool.setuptools]
 license-files = []
 
+[tool.uv]
+exclude-newer = "7 days"
+
 # Linting tools configuration
 [tool.ruff]
 line-length = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,12 @@ version = {attr = "jubilant.__version__"}
 license-files = []
 
 [tool.uv]
+# Rolling quarantine: never resolve against packages published in the last 7
+# days, so a compromised release has a window to be caught/yanked upstream
+# before it can reach this project via a manual `uv add`, a `uv lock` regen,
+# a uvx bootstrap, or a CI re-resolve. Complements (doesn't replace) the
+# Dependabot cooldown, which only protects Dependabot-authored PRs.
 exclude-newer = "7 days"
-no-build = true
 
 # Linting tools configuration
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ license-files = []
 
 [tool.uv]
 exclude-newer = "7 days"
+no-build = true
 
 # Linting tools configuration
 [tool.ruff]


### PR DESCRIPTION
Adds a rolling package-level cooldown in `[tool.uv]`:

```toml
exclude-newer = "7 days"
```

uv refuses to resolve against any package published in the last 7 days, so a compromised release has a window to be caught / yanked upstream before it can enter this project. Complements (does not replace) the Dependabot cooldown, which only protects Dependabot-authored PRs — `exclude-newer` also covers manual `uv add`, `uv lock` regens, `uvx` bootstraps, and CI re-resolves, which Dependabot cooldown alone doesn't reach.