### PR TITLE
chore: run uv lock after adding exclude-newer duration

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "cffi"
 version = "2.0.0"


### PR DESCRIPTION
I'm sorry for the noise.

In https://github.com/canonical/jubilant/pull/370, I ran `uv lock` before pulling in the changes from https://github.com/canonical/jubilant/pull/368. I didn't expect 

```
[tool.uv]
exclude-newer = "7 days"
```
to write into `uv.lock`, the next time you run `uv` commands (in Jubilant, it happened when I ran `make lint`):

```
[options]
exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
exclude-newer-span = "P7D"
```

The `exclude-newer = "0001-01-01T00:00:00Z"` behavior is mentioned here - https://github.com/astral-sh/uv/pull/19022. 

This PR adds that part in, or else it would update `uv.lock` everytime. The changes to `uv.lock` looks good to me, and I verified that `exclude-newer` still works as expected (I tried `uv add uv==0.11.28`).