### PR TITLE
ci: correct hash-pin version comment for upload-sarif action

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -28,7 +28,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
zizmor's ref-version-mismatch audit flagged that the github/codeql-action/upload-sarif hash pin carried a `# v4` comment while the pinned commit is actually tag v4.36.2. The hash is unchanged; only the comment is corrected to accurately reflect the pinned version.