### PR TITLE
chore: bump version and add changes for release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Features
 
 * Improve Jubilant logging mechanism (#351)
+* Bump minimum python version to 3.10 (#370)
 
 ## Chores
 
@@ -15,7 +16,6 @@
 
 * Adopt new dependabot conventions (#365)
 * Hash-pin actions and drop zizmor config (#366)
-* Bump minimum python version to 3.10 (#370)
 * Correct hash-pin version comment for upload-sarif action (#376)
 * Pin action version comments to exact tags (#378)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,24 @@
+# 1.12.0 - 30 Jul 2026
+
+## Features
+
+* Improve Jubilant logging mechanism (#351)
+
+## Chores
+
+* Rolling uv exclude-newer supply-chain quarantine (#368)
+* Set dependabot commit-message prefix to "chore" (no scope) (#367)
+* Add Code of Conduct linking to Ubuntu CoC (#356)
+* Run uv lock after adding exclude-newer duration (#372)
+
+## CI
+
+* Adopt new dependabot conventions (#365)
+* Hash-pin actions and drop zizmor config (#366)
+* Bump minimum python version to 3.10 (#370)
+* Correct hash-pin version comment for upload-sarif action (#376)
+* Pin action version comments to exact tags (#378)
+
 # 1.11.0 - 29 Jun 2026
 
 ## Features

--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -55,4 +55,4 @@ __all__ = [
     'unittypes',
 ]
 
-__version__ = '1.11.0'
+__version__ = '1.12.0'


### PR DESCRIPTION
This PR prepares Jubilant for release.

Release notes:
```
v1.12.0: Improved Jubilant logging
```
```
This feature release improves Jubilant's logging, lowering the default verbosity and presenting app/unit status changes in an easier to read format. Read more: [Configure Jubilant logs](https://canonical.com/juju/docs/ops/latest/howto/write-integration-tests-for-a-charm/#configure-jubilant-logs).

## What's Changed
* feat: improve Jubilant logging mechanism in https://github.com/canonical/jubilant/pull/351
* feat: bump minimum python version to 3.10 in https://github.com/canonical/jubilant/pull/370
* chore: rolling uv exclude-newer supply-chain quarantine in https://github.com/canonical/jubilant/pull/368
* chore: set dependabot commit-message prefix to "chore" (no scope) in https://github.com/canonical/jubilant/pull/367
* chore: add Code of Conduct linking to Ubuntu CoC in https://github.com/canonical/jubilant/pull/356
* chore: run uv lock after adding exclude-newer duration in https://github.com/canonical/jubilant/pull/372
* ci: adopt new dependabot conventions in https://github.com/canonical/jubilant/pull/365
* ci: hash-pin actions and drop zizmor config in https://github.com/canonical/jubilant/pull/366
* ci: correct hash-pin version comment for upload-sarif action in https://github.com/canonical/jubilant/pull/376
* ci: pin action version comments to exact tags in https://github.com/canonical/jubilant/pull/378

**Full Changelog**: https://github.com/canonical/jubilant/compare/v1.11.0...v1.12.0
```