### PR TITLE
docs: update juju.wait doc string; update title of run-juju-cli-command how-to page; update juju.cli example

### DIFF
--- a/docs/how-to/run-juju-cli-commands.md
+++ b/docs/how-to/run-juju-cli-commands.md
@@ -9,16 +9,13 @@ myst:
 
 Many common Juju commands are already defined on the `Juju` class, such as [`deploy`](jubilant.Juju.deploy) and [`integrate`](jubilant.Juju.integrate). However, if you want to run a Juju command that's not yet defined in Jubilant, you can fall back to calling the [`Juju.cli`](jubilant.Juju.cli) method.
 
-For example, to fetch a model configuration value using `juju model-config`:
+For example, to scale a Kubernetes application using `juju scale-application`:
 
 ```python
 >>> import json
 >>> import jubilant
 >>> juju = jubilant.Juju(model='test')
->>> stdout = juju.cli('model-config', '--format=json')
->>> result = json.loads(stdout)
->>> result['automatically-retry-hooks']['Value']
-True
+>>> juju.cli('scale-application', 'myapp', '2')
 ```
 
 By default, `Juju.cli` adds a `--model=<model>` parameter if the `Juju` instance has a model set. To prevent this for commands not specific to a model, specify `include_model=False`:

--- a/docs/how-to/run-juju-cli-commands.md
+++ b/docs/how-to/run-juju-cli-commands.md
@@ -5,7 +5,7 @@ myst:
 ---
 
 (run_juju_cli_commands)=
-# How to run Juju CLI commands
+# How to run other Juju CLI commands
 
 Many common Juju commands are already defined on the `Juju` class, such as [`deploy`](jubilant.Juju.deploy) and [`integrate`](jubilant.Juju.integrate). However, if you want to run a Juju command that's not yet defined in Jubilant, you can fall back to calling the [`Juju.cli`](jubilant.Juju.cli) method.
 

--- a/jubilant/_juju.py
+++ b/jubilant/_juju.py
@@ -1680,7 +1680,7 @@ class Juju:
                 error=jubilant.any_error,
             )
 
-        For more examples, see `Tutorial | Use a custom wait condition <https://canonical.com/juju/docs/jubilant/tutorial/getting-started/#use-a-custom-wait-condition>`_.
+        For more examples, see `How to use a custom wait condition <https://canonical.com/juju/docs/jubilant/how-to/use-a-custom-wait-condition>`_.
 
         This function logs the status object after the first status call, and after subsequent
         calls if the status object has changed. Logs are sent to the logger named


### PR DESCRIPTION
This PR made minor doc related updates:
- In `juju.wait` doc string, the link to `How to use custom wait condition` is updated to the new location `https://canonical.com/juju/docs/jubilant/how-to/use-a-custom-wait-condition` after #383.
- Rename the title of `docs/how-to/run-juju-cli-commands.md` to `How to run other Juju CLI commands`

The current example in `How to run other Juju CLI commands` uses `model-config`, which was added in #106 . This PR replaces that example:
- With a juju command relevant to charm integration test (for example, found in a real charm).
- "model-scoped". `show-controller` is great, but it needs `include_model=False`, which is covered in the second example of the page.

I went with `scale-application`. This is used in some real charms, but we don't have a useful returned JSON data:
- [oauth2-proxy-k8s-operator](https://github.com/canonical/oauth2-proxy-k8s-operator/blob/0052696dc1858fdd0a5b29d409eaeb8ef402cd86/tests/integration/test_charm.py#L166)
- [loki-k8s-operator](https://github.com/canonical/loki-k8s-operator/blob/e87a761693c5d38b8bd4abb48d2ea7ea83807d00/tests/integration/test_alert_rules_fire.py#L70)

Please let me know if this works.

There is also a "paradox": a juju command not in Jubilant -> it is widely use as `juju.cli` -> more chance will be added to Jubilant :laughing: 