### PR TITLE
docs: cover the remaining SEC0030 sub-requirements

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -36,7 +36,7 @@ The library does not introduce any new security risks beyond directly running Ju
 
 Jubilant does not use any cryptographic technology, hashing, or digital signatures. All cryptographic operations (TLS, credential storage, API authentication) are handled by the Juju CLI and the Juju controller.
 
-There is correspondingly nothing to configure for data in transit or at rest. Jubilant opens no network connections, so the TLS protecting a controller connection is the CLI's to enable and configure. It stores nothing persistently either; the one thing it writes to disk is a temporary file used to pass a secret to the CLI without exposing it in the process arguments, deleted when the call returns. That file goes in the system temporary directory, or in `~/snap/juju/common` when the Juju CLI is a snap, since a confined snap cannot read `/tmp`.
+There is correspondingly nothing to configure for data in transit or at rest. Jubilant opens no network connections, so the TLS protecting a controller connection is the CLI's to enable and configure. Nothing is stored persistently: the temporary files described under [Product architecture](#product-architecture) are the only disk writes, and each is removed when the call returns.
 
 ## Configuring and operating
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -36,8 +36,6 @@ The library does not introduce any new security risks beyond directly running Ju
 
 Jubilant does not use any cryptographic technology, hashing, or digital signatures. All cryptographic operations (TLS, credential storage, API authentication) are handled by the Juju CLI and the Juju controller.
 
-There is correspondingly nothing to configure for data in transit or at rest. Jubilant opens no network connections, so the TLS protecting a controller connection is the CLI's to enable and configure. Nothing is stored persistently: the temporary files described under [Product architecture](#product-architecture) are the only disk writes, and each is removed when the call returns.
-
 ## Configuring and operating
 
 ### Hardening guidelines

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -36,6 +36,8 @@ The library does not introduce any new security risks beyond directly running Ju
 
 Jubilant does not use any cryptographic technology, hashing, or digital signatures. All cryptographic operations (TLS, credential storage, API authentication) are handled by the Juju CLI and the Juju controller.
 
+There is correspondingly nothing to configure for data in transit or at rest. Jubilant opens no network connections, so the TLS protecting a controller connection is the CLI's to enable and configure. It stores nothing persistently either; the one thing it writes to disk is a temporary file used to pass a secret to the CLI without exposing it in the process arguments, deleted when the call returns. That file goes in the system temporary directory, or in `~/snap/juju/common` when the Juju CLI is a snap, since a confined snap cannot read `/tmp`.
+
 ## Configuring and operating
 
 ### Hardening guidelines
@@ -59,6 +61,8 @@ For security-relevant events (login failures, credential errors, controller acce
 
 Secret and credential values are written to temporary files rather than CLI arguments, so they do not appear in Jubilant's logs. The exception is `CLIError`, raised on a Juju CLI failure: its traceback includes the CLI's `stdout` and `stderr`, so any value the Juju CLI itself echoes there would be exposed.
 
+Everything Jubilant emits goes through the `jubilant` logger, so that handler is the only control point: raise its level to capture less, or configure no handler at all to opt out entirely. There are no alerts to configure and no masking beyond the temporary files above, so a test is responsible for keeping secrets out of its own log messages, and for not printing a `CLIError` traceback somewhere the output is kept.
+
 ## Decommissioning
 
 Removing Jubilant from a project requires no special decommissioning steps. Remove `jubilant` from your `pyproject.toml` and re-lock dependencies. Jubilant stores no credentials, configuration, or logs of its own. Any Juju environments provisioned during testing should be destroyed using the Juju CLI (`juju destroy-controller`, `juju destroy-model`) independently of removing Jubilant.
@@ -70,6 +74,8 @@ Jubilant follows [semantic versioning](https://semver.org/). Security updates ar
 **Receiving security updates.** Restrict the version of `jubilant` in `pyproject.toml` in a way that allows picking up new compatible releases every time that you re-lock dependencies. For example, `jubilant~=1.2` allows upgrades to 1.3, 1.4, and so on, while staying on the 1.x line.
 
 **Detecting available updates.** Configure Dependabot or Renovate in your charm repository so that security updates are surfaced automatically as pull requests. Re-lock dependencies when prompted so that the charm tests run with the latest version.
+
+**Scheduling and postponing updates.** An update reaches you when you re-lock, so re-lock on a cadence rather than when someone happens to notice. Pinning to an exact version, or turning off the automated proposals above, postpones updates indefinitely: a published fix will not reach you until the pin is lifted. Jubilant runs with the credentials of whoever runs the tests, and against real controllers, so a machine or CI runner on a known-vulnerable version stays exposed for the whole of that delay.
 
 **Verifying an update.** Security releases are announced via [GitHub Security Advisories](https://github.com/canonical/jubilant/security/advisories) and as GitHub release notes. Verify that the installed version matches a published release by running `pip show jubilant` or `uv pip show jubilant` in the test environment.
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -59,7 +59,7 @@ For security-relevant events (login failures, credential errors, controller acce
 
 Secret and credential values are written to temporary files rather than CLI arguments, so they do not appear in Jubilant's logs. The exception is `CLIError`, raised on a Juju CLI failure: its traceback includes the CLI's `stdout` and `stderr`, so any value the Juju CLI itself echoes there would be exposed.
 
-In a test suite, everything Jubilant emits goes through the `jubilant` logger, so that handler is the only control point: raise its level to capture less, or configure no handler at all to opt out entirely. The `jubilant` command-line tool is different, and attaches its own handler to the root logger at a level set by `-q`/`-v`. There are no alerts to configure and no masking beyond the temporary files above, so a test is responsible for keeping secrets out of its own log messages, and for not printing `CLIError` tracebacks or `debug_log()` output somewhere the output is kept: neither passes through the logger.
+In a test suite, everything Jubilant emits goes through the `jubilant` logger, so that handler is the only control point: raise its level to capture less, or configure no handler at all to opt out entirely. The `jubilant` command-line tool is different, and attaches its own handler to the root logger at a level set by `-q`/`-v`. There are no alerts to configure and no masking beyond the temporary files above, so a test is responsible for keeping secrets out of its own log messages, and for not printing a `CLIError` traceback or `debug_log()` output somewhere the output is kept: neither passes through the logger.
 
 ## Decommissioning
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -61,7 +61,7 @@ For security-relevant events (login failures, credential errors, controller acce
 
 Secret and credential values are written to temporary files rather than CLI arguments, so they do not appear in Jubilant's logs. The exception is `CLIError`, raised on a Juju CLI failure: its traceback includes the CLI's `stdout` and `stderr`, so any value the Juju CLI itself echoes there would be exposed.
 
-Everything Jubilant emits goes through the `jubilant` logger, so that handler is the only control point: raise its level to capture less, or configure no handler at all to opt out entirely. There are no alerts to configure and no masking beyond the temporary files above, so a test is responsible for keeping secrets out of its own log messages, and for not printing a `CLIError` traceback somewhere the output is kept.
+In a test suite, everything Jubilant emits goes through the `jubilant` logger, so that handler is the only control point: raise its level to capture less, or configure no handler at all to opt out entirely. The `jubilant` command-line tool is different, and attaches its own handler to the root logger at a level set by `-q`/`-v`. There are no alerts to configure and no masking beyond the temporary files above, so a test is responsible for keeping secrets out of its own log messages, and for not printing `CLIError` tracebacks or `debug_log()` output somewhere the output is kept: neither passes through the logger.
 
 ## Decommissioning
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -59,7 +59,9 @@ For security-relevant events (login failures, credential errors, controller acce
 
 Secret and credential values are written to temporary files rather than CLI arguments, so they do not appear in Jubilant's logs. The exception is `CLIError`, raised on a Juju CLI failure: its traceback includes the CLI's `stdout` and `stderr`, so any value the Juju CLI itself echoes there would be exposed.
 
-In a test suite, everything Jubilant emits goes through the `jubilant` logger, so that handler is the only control point: raise its level to capture less, or configure no handler at all to opt out entirely. The `jubilant` command-line tool is different, and attaches its own handler to the root logger at a level set by `-q`/`-v`. There are no alerts to configure and no masking beyond the temporary files above, so a test is responsible for keeping secrets out of its own log messages, and for not printing a `CLIError` traceback or `debug_log()` output somewhere the output is kept: neither passes through the logger.
+In a test suite, everything Jubilant emits goes through the `jubilant` logger. Raise its level to capture less, or remove the handler to opt out. The `jubilant` command-line tool is different, and attaches its own handler to the root logger at a level set by `-q`/`-v`.
+
+There are no alerts to configure and no masking beyond the temporary files described above. Each test is responsible for keeping secrets out of log messages, and for not printing a `CLIError` traceback or `debug_log()` output somewhere the output is kept — both bypass the `jubilant` logger.
 
 ## Decommissioning
 
@@ -73,7 +75,7 @@ Jubilant follows [semantic versioning](https://semver.org/). Security updates ar
 
 **Detecting available updates.** Configure Dependabot or Renovate in your charm repository so that security updates are surfaced automatically as pull requests. Re-lock dependencies when prompted so that the charm tests run with the latest version.
 
-**Scheduling and postponing updates.** An update reaches you when you re-lock, so re-lock on a cadence rather than when someone happens to notice. Pinning to an exact version, or turning off the automated proposals above, postpones updates indefinitely: a published fix will not reach you until the pin is lifted. Jubilant runs with the credentials of whoever runs the tests, and against real controllers, so a machine or CI runner on a known-vulnerable version stays exposed for the whole of that delay.
+**Scheduling and postponing updates.** An update reaches you when you re-lock, so re-lock regularly rather than when someone notices a new version. Pinning to an exact version, or turning off the automated proposals above, postpones updates indefinitely. Jubilant runs with the credentials of whoever runs the tests, and against real controllers, so a machine or CI runner on a known-vulnerable version stays exposed until you re-lock.
 
 **Verifying an update.** Security releases are announced via [GitHub Security Advisories](https://github.com/canonical/jubilant/security/advisories) and as GitHub release notes. Verify that the installed version matches a published release by running `pip show jubilant` or `uv pip show jubilant` in the test environment.
 


### PR DESCRIPTION
A re-read of the security page against SEC0030 v1.3 turned up two sub-requirements not done: logging and monitoring item 4 (alerts, opting out, masking), and security lifecycle item 3 (scheduling or postponing an update, with a warning about the risk of delaying).

Lifecycle item 3 is the main gap: the page covered receiving, detecting and verifying an update, but not scheduling or postponing one, and had no risk warning.

Most of what item 4 it asks for doesn't apply here (there's no monitoring agent and no alert to configure). What the paragraph is actually for is the two things that don't go through the `jubilant` logger, `CLIError` tracebacks and `debug_log()` output, and scoping the bit about handlers to library use, since the `jubilant` command attaches its own to the root logger.