### PR TITLE
chore: bump version for release and update changes.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,20 +2,12 @@
 
 ## Features
 
-* Expose wait to CLI in (#374)
+* Expose wait to CLI (#374)
 
 ## Documentation
 
-* Extract howto guides from the tutorial in (#383)
-* Update `juju.wait` doc string; update title of `run-juju-cli-command` how-to page; update `juju.cli` example in (#396)
-
-## Chores
-
-* Bump cryptography from 48.0.1 to 49.0.0 in (#390)
-* Bump cryptography from 49.0.0 to 50.0.0 in (#394)
-* Bump the actions group with 6 updates in (#391)
-* Bump the test-deps group with 2 updates in (#387)
-* Bump the dev-tooling group across 1 directory with 4 updates in (#388)
+* Extract howto guides from the tutorial (#383)
+* Update `juju.wait` doc string; update title of `run-juju-cli-command` how-to page; update `juju.cli` example (#396)
 
 # 1.12.0 - 30 Jul 2026
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,22 @@
+# 1.13.0 - 31 Aug 2026
+
+## Features
+
+* Expose wait to CLI in (#374)
+
+## Documentation
+
+* Extract howto guides from the tutorial in (#383)
+* Update `juju.wait` doc string; update title of `run-juju-cli-command` how-to page; update `juju.cli` example in (#396)
+
+## Chores
+
+* Bump cryptography from 48.0.1 to 49.0.0 in (#390)
+* Bump cryptography from 49.0.0 to 50.0.0 in (#394)
+* Bump the actions group with 6 updates in (#391)
+* Bump the test-deps group with 2 updates in (#387)
+* Bump the dev-tooling group across 1 directory with 4 updates in (#388)
+
 # 1.12.0 - 30 Jul 2026
 
 ## Features

--- a/jubilant/__init__.py
+++ b/jubilant/__init__.py
@@ -55,4 +55,4 @@ __all__ = [
     'unittypes',
 ]
 
-__version__ = '1.12.0'
+__version__ = '1.13.0'


### PR DESCRIPTION
This PR prepares release v1.13.0

**Title**
```
v1.13.0 - Jubilant's wait on CLI
```

**Release notes**

```
This release features a new CLI entrypoint that allows running Jubilant's `wait` method from the CLI. See https://github.com/canonical/jubilant/pull/374 for some examples.

This release also adds a [how-to guide section](https://canonical.com/juju/docs/jubilant/how-to/) in the docs.

## What's Changed
* feat: expose wait to CLI in https://github.com/canonical/jubilant/pull/374
* docs: extract howto guides from the tutorial in https://github.com/canonical/jubilant/pull/383
* docs: update juju.wait docstring; update title of run-juju-cli-command how-to page; update juju.cli example in https://github.com/canonical/jubilant/pull/396

**Full Changelog**: https://github.com/canonical/jubilant/compare/v1.12.0...v1.13.0
```