### PR TITLE
ci: swap attest-build-provenance for actions/attest

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
         run: uv build
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6  # v4.2.2
         with:
           subject-path: 'dist/*'
 


### PR DESCRIPTION
`actions/attest-build-provenance` has been a thin wrapper around `actions/attest` since its v4.0.0, and its release notes recommend using `actions/attest` directly, so this swaps the action.

With no predicate inputs, `actions/attest` defaults to build provenance, so `subject-path` is the only input either action needs and the job permissions are unchanged.